### PR TITLE
补全读取保存设置的功能

### DIFF
--- a/GTA5Menu/Views/ExternalMenu/OnlineOptionView.xaml
+++ b/GTA5Menu/Views/ExternalMenu/OnlineOptionView.xaml
@@ -59,44 +59,54 @@
                     <CheckBox
                         x:Name="CheckBox_PassiveModeCooldown"
                         Click="CheckBox_PassiveModeCooldown_Click"
+                        IsChecked="{Binding OP_Options.PassiveModeCooldown, UpdateSourceTrigger=PropertyChanged}"
                         Content="移除被动模式冷却" />
                     <CheckBox
                         x:Name="CheckBox_SuicideCooldown"
                         Click="CheckBox_SuicideCooldown_Click"
+                        IsChecked="{Binding OP_Options.SuicideCooldown, UpdateSourceTrigger=PropertyChanged}"
                         Content="移除自杀冷却" />
                     <CheckBox
                         x:Name="CheckBox_OrbitalCooldown"
                         Click="CheckBox_OrbitalCooldown_Click"
+                        IsChecked="{Binding OP_Options.OrbitalCooldown, UpdateSourceTrigger=PropertyChanged}"
                         Content="移除天基炮冷却" />
                     <CheckBox
                         x:Name="CheckBox_SellOnNonPublic"
                         Click="CheckBox_SellOnNonPublic_Click"
+                        IsChecked="{Binding OP_Options.SellOnNonPublic, UpdateSourceTrigger=PropertyChanged}"
                         Content="非公开战局运货" />
                     <CheckBox
                         x:Name="CheckBox_SessionSnow"
                         Click="CheckBox_SessionSnow_Click"
+                        IsChecked="{Binding OP_Options.SessionSnow, UpdateSourceTrigger=PropertyChanged}"
                         Content="战局雪天 (自己可见)" />
                 </StackPanel>
                 <StackPanel>
                     <CheckBox
                         x:Name="CheckBox_OffRadar"
                         Click="CheckBox_OffRadar_Click"
+                        IsChecked="{Binding OP_Options.OffRadar, UpdateSourceTrigger=PropertyChanged}"
                         Content="雷达影踪" />
                     <CheckBox
                         x:Name="CheckBox_GhostOrganization"
                         Click="CheckBox_GhostOrganization_Click"
+                        IsChecked="{Binding OP_Options.GhostOrganization, UpdateSourceTrigger=PropertyChanged}"
                         Content="幽灵组织" />
                     <CheckBox
                         x:Name="CheckBox_BribeOrBlindCops"
                         Click="CheckBox_BribeOrBlindCops_Click"
+                        IsChecked="{Binding OP_Options.BribeOrBlindCops, UpdateSourceTrigger=PropertyChanged}"
                         Content="警察无视犯罪" />
                     <CheckBox
                         x:Name="CheckBox_BribeAuthorities"
                         Click="CheckBox_BribeAuthorities_Click"
+                        IsChecked="{Binding OP_Options.BribeAuthorities, UpdateSourceTrigger=PropertyChanged}"
                         Content="贿赂当局" />
                     <CheckBox
                         x:Name="CheckBox_RevealPlayers"
                         Click="CheckBox_RevealPlayers_Click"
+                        IsChecked="{Binding OP_Options.RevealPlayers, UpdateSourceTrigger=PropertyChanged}"
                         Content="显示玩家" />
                 </StackPanel>
             </UniformGrid>

--- a/GTA5Menu/Views/ExternalMenu/OnlineOptionView.xaml.cs
+++ b/GTA5Menu/Views/ExternalMenu/OnlineOptionView.xaml.cs
@@ -1,4 +1,5 @@
-﻿using GTA5Core.Features;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using GTA5Core.Features;
 using GTA5Core.GTA.Onlines;
 using GTA5Shared.Helper;
 
@@ -9,56 +10,114 @@ namespace GTA5Menu.Views.ExternalMenu;
 /// </summary>
 public partial class OnlineOptionView : UserControl
 {
-    private class Options
+    public partial class Options : ObservableObject
     {
-        public bool FreeChangeAppearance = false;
-        public bool ChangeAppearanceCooldown = false;
+        [ObservableProperty] public bool freeChangeAppearance = false;
+        [ObservableProperty] public bool changeAppearanceCooldown = false;
 
-        public bool PassiveModeCooldown = false;
-        public bool SuicideCooldown = false;
-        public bool OrbitalCooldown = false;
-        public bool SellOnNonPublic = false;
-        public bool SessionSnow = false;
+        [ObservableProperty] public bool passiveModeCooldown = false;
+        [ObservableProperty] public bool suicideCooldown = false;
+        [ObservableProperty] public bool orbitalCooldown = false;
+        [ObservableProperty] public bool sellOnNonPublic = false;
+        [ObservableProperty] public bool sessionSnow = false;
+
+        [ObservableProperty] public bool offRadar = false;
+        [ObservableProperty] public bool ghostOrganization = false;
+        [ObservableProperty] public bool bribeOrBlindCops = false;
+        [ObservableProperty] public bool bribeAuthorities = false;
+        [ObservableProperty] public bool revealPlayers = false;
+
     }
-    private readonly Options _options = new();
+    public Options OP_Options { set; get; } = new();
 
     public OnlineOptionView()
     {
         InitializeComponent();
         GTA5MenuWindow.WindowClosingEvent += GTA5MenuWindow_WindowClosingEvent;
         GTA5MenuWindow.LoopSpeedNormalEvent += GTA5MenuWindow_LoopSpeedNormalEvent;
+
+        ReadConfig();
     }
 
     private void GTA5MenuWindow_WindowClosingEvent()
     {
         GTA5MenuWindow.WindowClosingEvent -= GTA5MenuWindow_WindowClosingEvent;
         GTA5MenuWindow.LoopSpeedNormalEvent -= GTA5MenuWindow_LoopSpeedNormalEvent;
+
+        SaveConfig();
     }
+
+    private void SaveConfig()
+    {
+        IniHelper.WriteValue("OnlineOption", "PassiveModeCooldown", $"{OP_Options.PassiveModeCooldown}");
+        IniHelper.WriteValue("OnlineOption", "SuicideCooldown", $"{OP_Options.SuicideCooldown}");
+        IniHelper.WriteValue("OnlineOption", "OrbitalCooldown", $"{OP_Options.OrbitalCooldown}");
+        IniHelper.WriteValue("OnlineOption", "SellOnNonPublic", $"{OP_Options.SellOnNonPublic}");
+        IniHelper.WriteValue("OnlineOption", "SessionSnow", $"{OP_Options.SessionSnow}");
+
+        IniHelper.WriteValue("OnlineOption", "OffRadar", $"{OP_Options.OffRadar}");
+        IniHelper.WriteValue("OnlineOption", "GhostOrganization", $"{OP_Options.GhostOrganization}");
+        IniHelper.WriteValue("OnlineOption", "BribeOrBlindCops", $"{OP_Options.BribeOrBlindCops}");
+        IniHelper.WriteValue("OnlineOption", "BribeAuthorities", $"{OP_Options.BribeAuthorities}");
+        IniHelper.WriteValue("OnlineOption", "RevealPlayers", $"{OP_Options.RevealPlayers}");
+    }
+
+    private void ReadConfig()
+    {
+        OP_Options.PassiveModeCooldown = IniHelper.ReadValue("OnlineOption", "PassiveModeCooldown").Equals("True", StringComparison.OrdinalIgnoreCase);
+        OP_Options.SuicideCooldown = IniHelper.ReadValue("OnlineOption", "SuicideCooldown").Equals("True", StringComparison.OrdinalIgnoreCase);
+        OP_Options.OrbitalCooldown = IniHelper.ReadValue("OnlineOption", "OrbitalCooldown").Equals("True", StringComparison.OrdinalIgnoreCase);
+        OP_Options.SellOnNonPublic = IniHelper.ReadValue("OnlineOption", "SellOnNonPublic").Equals("True", StringComparison.OrdinalIgnoreCase);
+        OP_Options.SessionSnow = IniHelper.ReadValue("OnlineOption", "SessionSnow").Equals("True", StringComparison.OrdinalIgnoreCase);
+
+        OP_Options.OffRadar = IniHelper.ReadValue("OnlineOption", "OffRadar").Equals("True", StringComparison.OrdinalIgnoreCase);
+        OP_Options.GhostOrganization = IniHelper.ReadValue("OnlineOption", "GhostOrganization").Equals("True", StringComparison.OrdinalIgnoreCase);
+        OP_Options.BribeOrBlindCops = IniHelper.ReadValue("OnlineOption", "BribeOrBlindCops").Equals("True", StringComparison.OrdinalIgnoreCase);
+        OP_Options.BribeAuthorities = IniHelper.ReadValue("OnlineOption", "BribeAuthorities").Equals("True", StringComparison.OrdinalIgnoreCase);
+        OP_Options.RevealPlayers = IniHelper.ReadValue("OnlineOption", "RevealPlayers").Equals("True", StringComparison.OrdinalIgnoreCase);
+    }
+
 
     private void GTA5MenuWindow_LoopSpeedNormalEvent()
     {
         // 免费更改角色外观
-        if (_options.FreeChangeAppearance)
+        if (OP_Options.FreeChangeAppearance)
             Online.FreeChangeAppearance(true);
         // 移除更改角色外观冷却
-        if (_options.ChangeAppearanceCooldown)
+        if (OP_Options.ChangeAppearanceCooldown)
             Online.ChangeAppearanceCooldown(true);
 
         // 移除被动模式冷却
-        if (_options.PassiveModeCooldown)
+        if (OP_Options.PassiveModeCooldown)
             Online.PassiveModeCooldown(true);
         // 移除自杀冷却
-        if (_options.SuicideCooldown)
+        if (OP_Options.SuicideCooldown)
             Online.SuicideCooldown(true);
         // 移除天基炮冷却
-        if (_options.OrbitalCooldown)
+        if (OP_Options.OrbitalCooldown)
             Online.OrbitalCooldown(true);
         // 非公开战局运货
-        if (_options.SellOnNonPublic)
+        if (OP_Options.SellOnNonPublic)
             Online.SellOnNonPublic(true);
         // 战局雪天 (自己可见)
-        if (_options.SessionSnow)
+        if (OP_Options.SessionSnow)
             Online.SessionSnow(true);
+
+        // 雷达影踪
+        if (OP_Options.OffRadar)
+            Online.OffRadar(true);
+        // 幽灵组织
+        if (OP_Options.GhostOrganization)
+            Online.GhostOrganization(true);
+        // 警察无视犯罪
+        if (OP_Options.BribeOrBlindCops)
+            Online.BribeOrBlindCops(true);
+        // 贿赂当局
+        if (OP_Options.BribeAuthorities)
+            Online.BribeAuthorities(true);
+        // 显示玩家
+        if (OP_Options.RevealPlayers)
+            Online.RevealPlayers(true);
     }
 
     /////////////////////////////////////////////////////////////
@@ -100,73 +159,79 @@ public partial class OnlineOptionView : UserControl
 
     private void CheckBox_FreeChangeAppearance_Click(object sender, RoutedEventArgs e)
     {
-        _options.FreeChangeAppearance = CheckBox_FreeChangeAppearance.IsChecked == true;
-        Online.FreeChangeAppearance(_options.FreeChangeAppearance);
+        OP_Options.FreeChangeAppearance = CheckBox_FreeChangeAppearance.IsChecked == true;
+        Online.FreeChangeAppearance(OP_Options.FreeChangeAppearance);
     }
 
     private void CheckBox_ChangeAppearanceCooldown_Click(object sender, RoutedEventArgs e)
     {
-        _options.ChangeAppearanceCooldown = CheckBox_ChangeAppearanceCooldown.IsChecked == true;
-        Online.ChangeAppearanceCooldown(_options.ChangeAppearanceCooldown);
+        OP_Options.ChangeAppearanceCooldown = CheckBox_ChangeAppearanceCooldown.IsChecked == true;
+        Online.ChangeAppearanceCooldown(OP_Options.ChangeAppearanceCooldown);
     }
 
     private void CheckBox_PassiveModeCooldown_Click(object sender, RoutedEventArgs e)
     {
-        _options.PassiveModeCooldown = CheckBox_PassiveModeCooldown.IsChecked == true;
-        Online.PassiveModeCooldown(_options.PassiveModeCooldown);
+        OP_Options.PassiveModeCooldown = CheckBox_PassiveModeCooldown.IsChecked == true;
+        Online.PassiveModeCooldown(OP_Options.PassiveModeCooldown);
     }
 
     private void CheckBox_SuicideCooldown_Click(object sender, RoutedEventArgs e)
     {
-        _options.SuicideCooldown = CheckBox_SuicideCooldown.IsChecked == true;
-        Online.SuicideCooldown(_options.SuicideCooldown);
+        OP_Options.SuicideCooldown = CheckBox_SuicideCooldown.IsChecked == true;
+        Online.SuicideCooldown(OP_Options.SuicideCooldown);
     }
 
     private void CheckBox_OrbitalCooldown_Click(object sender, RoutedEventArgs e)
     {
-        _options.OrbitalCooldown = CheckBox_OrbitalCooldown.IsChecked == true;
-        Online.OrbitalCooldown(_options.OrbitalCooldown);
+        OP_Options.OrbitalCooldown = CheckBox_OrbitalCooldown.IsChecked == true;
+        Online.OrbitalCooldown(OP_Options.OrbitalCooldown);
     }
 
     private void CheckBox_SellOnNonPublic_Click(object sender, RoutedEventArgs e)
     {
-        _options.SellOnNonPublic = CheckBox_SellOnNonPublic.IsChecked == true;
-        Online.SellOnNonPublic(_options.SellOnNonPublic);
+        OP_Options.SellOnNonPublic = CheckBox_SellOnNonPublic.IsChecked == true;
+        Online.SellOnNonPublic(OP_Options.SellOnNonPublic);
     }
 
     private void CheckBox_SessionSnow_Click(object sender, RoutedEventArgs e)
     {
-        _options.SessionSnow = CheckBox_SessionSnow.IsChecked == true;
-        Online.SessionSnow(_options.SessionSnow);
+        OP_Options.SessionSnow = CheckBox_SessionSnow.IsChecked == true;
+        Online.SessionSnow(OP_Options.SessionSnow);
     }
 
     /////////////////////////////////////////////////////////////
 
     private void CheckBox_OffRadar_Click(object sender, RoutedEventArgs e)
     {
-        Online.OffRadar(CheckBox_OffRadar.IsChecked == true);
+        OP_Options.OffRadar = CheckBox_OffRadar.IsChecked == true;
+        Online.OffRadar(OP_Options.OffRadar);
     }
 
     private void CheckBox_GhostOrganization_Click(object sender, RoutedEventArgs e)
     {
-        Online.GhostOrganization(CheckBox_GhostOrganization.IsChecked == true);
+        OP_Options.GhostOrganization = CheckBox_GhostOrganization.IsChecked == true;
+        Online.GhostOrganization(OP_Options.GhostOrganization);
     }
 
     private void CheckBox_BribeOrBlindCops_Click(object sender, RoutedEventArgs e)
     {
-        Online.BribeOrBlindCops(CheckBox_BribeOrBlindCops.IsChecked == true);
+        OP_Options.BribeOrBlindCops = CheckBox_BribeOrBlindCops.IsChecked == true;
+        Online.BribeOrBlindCops(OP_Options.BribeOrBlindCops);
     }
 
     private void CheckBox_BribeAuthorities_Click(object sender, RoutedEventArgs e)
     {
-        Online.BribeAuthorities(CheckBox_BribeAuthorities.IsChecked == true);
+        OP_Options.BribeAuthorities = CheckBox_BribeAuthorities.IsChecked == true;
+        Online.BribeAuthorities(OP_Options.BribeAuthorities);
     }
 
     private void CheckBox_RevealPlayers_Click(object sender, RoutedEventArgs e)
     {
-        Online.RevealPlayers(CheckBox_RevealPlayers.IsChecked == true);
+        OP_Options.RevealPlayers = CheckBox_RevealPlayers.IsChecked == true;
+        Online.RevealPlayers(OP_Options.RevealPlayers);
     }
 
+    //////////////////////////////////////////////////////////////////
     private void Button_Blips_Click(object sender, RoutedEventArgs e)
     {
         AudioHelper.PlayClickSound();

--- a/GTA5Menu/Views/ExternalMenu/SelfStateView.xaml
+++ b/GTA5Menu/Views/ExternalMenu/SelfStateView.xaml
@@ -79,28 +79,34 @@
                     <CheckBox
                         x:Name="CheckBox_PlayerGodMode"
                         Click="CheckBox_PlayerGodMode_Click"
+                        IsChecked="{Binding SelfStateOption.GodMode, UpdateSourceTrigger=PropertyChanged}"
                         Content="玩家无敌" />
                     <CheckBox
                         x:Name="CheckBox_AntiAFK"
                         Click="CheckBox_AntiAFK_Click"
+                        IsChecked="{Binding SelfStateOption.AntiAFK, UpdateSourceTrigger=PropertyChanged}"
                         Content="挂机防踢" />
                     <CheckBox
                         x:Name="CheckBox_NoRagdoll"
                         Click="CheckBox_NoRagdoll_Click"
+                        IsChecked="{Binding SelfStateOption.NoRagdoll, UpdateSourceTrigger=PropertyChanged}"
                         Content="无布娃娃" />
                 </StackPanel>
                 <StackPanel>
                     <CheckBox
                         x:Name="CheckBox_UndeadOffRadar"
                         Click="CheckBox_UndeadOffRadar_Click"
+                        IsChecked="{Binding SelfStateOption.UndeadOffRadar, UpdateSourceTrigger=PropertyChanged}"
                         Content="雷达影踪（假死）" />
                     <CheckBox
                         x:Name="CheckBox_NPCIgnore"
                         Click="CheckBox_NPCIgnore_Click"
+                        IsChecked="{Binding SelfStateOption.NPCIgnore, UpdateSourceTrigger=PropertyChanged}"
                         Content="NPC无视" />
                     <CheckBox
                         x:Name="CheckBox_PoliceIgnore"
                         Click="CheckBox_NPCIgnore_Click"
+                        IsChecked="{Binding SelfStateOption.PoliceIgnore, UpdateSourceTrigger=PropertyChanged}"
                         Content="警察无视" />
                 </StackPanel>
             </UniformGrid>
@@ -181,18 +187,22 @@
                 <CheckBox
                     x:Name="CheckBox_AutoClearWanted"
                     Click="CheckBox_AutoClearWanted_Click"
+                    IsChecked="{Binding SelfStateOption.ClearWanted, UpdateSourceTrigger=PropertyChanged}"
                     Content="自动消星" />
                 <CheckBox
                     x:Name="CheckBox_AutoKillNPC"
                     Click="CheckBox_AutoKillNPC_Click"
+                    IsChecked="{Binding SelfStateOption.KillNPC, UpdateSourceTrigger=PropertyChanged}"
                     Content="自动击杀NPC" />
                 <CheckBox
                     x:Name="CheckBox_AutoKillHostilityNPC"
                     Click="CheckBox_AutoKillHostilityNPC_Click"
+                    IsChecked="{Binding SelfStateOption.KillHostilityNPC, UpdateSourceTrigger=PropertyChanged}"
                     Content="自动击杀敌对NPC" />
                 <CheckBox
                     x:Name="CheckBox_AutoKillPolice"
                     Click="CheckBox_AutoKillPolice_Click"
+                    IsChecked="{Binding SelfStateOption.KillPolice, UpdateSourceTrigger=PropertyChanged}"
                     Content="自动击杀警察" />
             </StackPanel>
 
@@ -201,34 +211,42 @@
                 <CheckBox
                     x:Name="CheckBox_ProofBullet"
                     Click="CheckBox_ProofBullet_Click"
+                    IsChecked="{Binding SelfStateOption.ProofBullet, UpdateSourceTrigger=PropertyChanged}"
                     Content="防子弹（防止子弹掉血）" />
                 <CheckBox
                     x:Name="CheckBox_ProofFire"
                     Click="CheckBox_ProofFire_Click"
+                    IsChecked="{Binding SelfStateOption.ProofFire, UpdateSourceTrigger=PropertyChanged}"
                     Content="防火烧（防止燃烧掉血）" />
                 <CheckBox
                     x:Name="CheckBox_ProofCollision"
                     Click="CheckBox_ProofCollision_Click"
+                    IsChecked="{Binding SelfStateOption.ProofCollision, UpdateSourceTrigger=PropertyChanged}"
                     Content="防撞击（防止撞击掉血）" />
                 <CheckBox
                     x:Name="CheckBox_ProofMelee"
                     Click="CheckBox_ProofMelee_Click"
+                    IsChecked="{Binding SelfStateOption.ProofMelee, UpdateSourceTrigger=PropertyChanged}"
                     Content="防近战（防止近战掉血）" />
                 <CheckBox
                     x:Name="CheckBox_ProofExplosion"
                     Click="CheckBox_ProofExplosion_Click"
+                    IsChecked="{Binding SelfStateOption.ProofExplosion, UpdateSourceTrigger=PropertyChanged}"
                     Content="防爆炸（防止爆炸掉血）" />
                 <CheckBox
                     x:Name="CheckBox_ProofSteam"
                     Click="CheckBox_ProofSteam_Click"
+                    IsChecked="{Binding SelfStateOption.ProofSteam, UpdateSourceTrigger=PropertyChanged}"
                     Content="防蒸汽（具体场景未知）" />
                 <CheckBox
                     x:Name="CheckBox_ProofDrown"
                     Click="CheckBox_ProofDrown_Click"
+                    IsChecked="{Binding SelfStateOption.ProofDrown, UpdateSourceTrigger=PropertyChanged}"
                     Content="防溺水（具体场景未知）" />
                 <CheckBox
                     x:Name="CheckBox_ProofWater"
                     Click="CheckBox_ProofWater_Click"
+                    IsChecked="{Binding SelfStateOption.ProofWater, UpdateSourceTrigger=PropertyChanged}"
                     Content="防海水（可以水下行走）" />
             </StackPanel>
         </StackPanel>

--- a/GTA5Menu/Views/ExternalMenu/SelfStateView.xaml.cs
+++ b/GTA5Menu/Views/ExternalMenu/SelfStateView.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using GTA5Menu.Models;
-
 using GTA5HotKey;
 using GTA5Core.Native;
 using GTA5Core.Offsets;
@@ -7,6 +6,7 @@ using GTA5Core.Features;
 using GTA5Core.GTA.Rage;
 using GTA5Core.GTA.Enum;
 using GTA5Shared.Helper;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace GTA5Menu.Views.ExternalMenu;
 
@@ -20,33 +20,33 @@ public partial class SelfStateView : UserControl
     /// </summary>
     public SelfStateModel SelfStateModel { get; set; } = new();
 
-    private class Options
+    public partial class Options : ObservableObject
     {
-        public bool GodMode = false;
-        public bool AntiAFK = false;
-        public bool NoRagdoll = false;
+        [ObservableProperty] public bool godMode = false;
+        [ObservableProperty] public bool antiAFK = false;
+        [ObservableProperty] public bool noRagdoll = false;
 
-        public bool UndeadOffRadar = false;
-        public bool NPCIgnore = false;
-        public bool PoliceIgnore = false;
+        [ObservableProperty] public bool undeadOffRadar = false;
+        [ObservableProperty] public bool nPCIgnore = false;
+        [ObservableProperty] public bool policeIgnore = false;
 
-        public bool NoCollision = false;
+        [ObservableProperty] public bool noCollision = false;
 
-        public bool ClearWanted = false;
-        public bool KillNPC = false;
-        public bool KillHostilityNPC = false;
-        public bool KillPolice = false;
+        [ObservableProperty] public bool clearWanted = false;
+        [ObservableProperty] public bool killNPC = false;
+        [ObservableProperty] public bool killHostilityNPC = false;
+        [ObservableProperty] public bool killPolice = false;
 
-        public bool ProofBullet = false;
-        public bool ProofFire = false;
-        public bool ProofCollision = false;
-        public bool ProofMelee = false;
-        public bool ProofExplosion = false;
-        public bool ProofSteam = false;
-        public bool ProofDrown = false;
-        public bool ProofWater = false;
+        [ObservableProperty] public bool proofBullet = false;
+        [ObservableProperty] public bool proofFire = false;
+        [ObservableProperty] public bool proofCollision = false;
+        [ObservableProperty] public bool proofMelee = false;
+        [ObservableProperty] public bool proofExplosion = false;
+        [ObservableProperty] public bool proofSteam = false;
+        [ObservableProperty] public bool proofDrown = false;
+        [ObservableProperty] public bool proofWater = false;
     }
-    private readonly Options _options = new();
+    public Options SelfStateOption { get; set; } = new();
 
     /////////////////////////////////////////////////////////
 
@@ -110,6 +110,16 @@ public partial class SelfStateView : UserControl
     /// </summary>
     private void ReadConfig()
     {
+        // 一般选项
+        SelfStateOption.GodMode = IniHelper.ReadValue("ExternalMenu", "GodMode").Equals("True", StringComparison.OrdinalIgnoreCase);
+        SelfStateOption.AntiAFK = IniHelper.ReadValue("ExternalMenu", "AntiAFK").Equals("True", StringComparison.OrdinalIgnoreCase);
+        SelfStateOption.NoRagdoll = IniHelper.ReadValue("ExternalMenu", "NoRagdoll").Equals("True", StringComparison.OrdinalIgnoreCase);
+
+        SelfStateOption.UndeadOffRadar = IniHelper.ReadValue("ExternalMenu", "UndeadOffRadar").Equals("True", StringComparison.OrdinalIgnoreCase);
+        SelfStateOption.NPCIgnore = IniHelper.ReadValue("ExternalMenu", "NPCIgnore").Equals("True", StringComparison.OrdinalIgnoreCase);
+        SelfStateOption.PoliceIgnore = IniHelper.ReadValue("ExternalMenu", "PoliceIgnore").Equals("True", StringComparison.OrdinalIgnoreCase);
+
+        // 快捷键
         SelfStateModel.IsHotKeyToWaypoint = IniHelper.ReadValue("ExternalMenu", "IsHotKeyToWaypoint").Equals("True", StringComparison.OrdinalIgnoreCase);
         SelfStateModel.IsHotKeyToObjective = IniHelper.ReadValue("ExternalMenu", "IsHotKeyToObjective").Equals("True", StringComparison.OrdinalIgnoreCase);
         SelfStateModel.IsHotKeyFillHealthArmor = IniHelper.ReadValue("ExternalMenu", "IsHotKeyFillHealthArmor").Equals("True", StringComparison.OrdinalIgnoreCase);
@@ -120,6 +130,22 @@ public partial class SelfStateView : UserControl
 
         SelfStateModel.IsHotKeyNoCollision = IniHelper.ReadValue("ExternalMenu", "IsHotKeyNoCollision").Equals("True", StringComparison.OrdinalIgnoreCase);
         SelfStateModel.IsHotKeyToCrossHair = IniHelper.ReadValue("ExternalMenu", "IsHotKeyToCrossHair").Equals("True", StringComparison.OrdinalIgnoreCase);
+
+        //实用功能
+        SelfStateOption.ClearWanted = IniHelper.ReadValue("ExternalMenu", "ClearWanted").Equals("True", StringComparison.OrdinalIgnoreCase);
+        SelfStateOption.KillNPC = IniHelper.ReadValue("ExternalMenu", "KillNPC").Equals("True", StringComparison.OrdinalIgnoreCase);
+        SelfStateOption.KillHostilityNPC = IniHelper.ReadValue("ExternalMenu", "KillHostilityNPC").Equals("True", StringComparison.OrdinalIgnoreCase);
+        SelfStateOption.KillPolice = IniHelper.ReadValue("ExternalMenu", "KillPolice").Equals("True", StringComparison.OrdinalIgnoreCase);
+
+        //高级
+        SelfStateOption.ProofBullet = IniHelper.ReadValue("ExternalMenu", "ProofBullet").Equals("True", StringComparison.OrdinalIgnoreCase);
+        SelfStateOption.ProofFire = IniHelper.ReadValue("ExternalMenu", "ProofFire").Equals("True", StringComparison.OrdinalIgnoreCase);
+        SelfStateOption.ProofCollision = IniHelper.ReadValue("ExternalMenu", "ProofCollision").Equals("True", StringComparison.OrdinalIgnoreCase);
+        SelfStateOption.ProofMelee = IniHelper.ReadValue("ExternalMenu", "ProofMelee").Equals("True", StringComparison.OrdinalIgnoreCase);
+        SelfStateOption.ProofExplosion = IniHelper.ReadValue("ExternalMenu", "ProofExplosion").Equals("True", StringComparison.OrdinalIgnoreCase);
+        SelfStateOption.ProofSteam = IniHelper.ReadValue("ExternalMenu", "ProofSteam").Equals("True", StringComparison.OrdinalIgnoreCase);
+        SelfStateOption.ProofDrown = IniHelper.ReadValue("ExternalMenu", "ProofDrown").Equals("True", StringComparison.OrdinalIgnoreCase);
+        SelfStateOption.ProofWater = IniHelper.ReadValue("ExternalMenu", "ProofWater").Equals("True", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -127,6 +153,16 @@ public partial class SelfStateView : UserControl
     /// </summary>
     private void SaveConfig()
     {
+        //一般选项
+        IniHelper.WriteValue("ExternalMenu", "GodMode", $"{SelfStateOption.GodMode}");
+        IniHelper.WriteValue("ExternalMenu", "AntiAFK", $"{SelfStateOption.AntiAFK}");
+        IniHelper.WriteValue("ExternalMenu", "NoRagdoll", $"{SelfStateOption.NoRagdoll}");
+
+        IniHelper.WriteValue("ExternalMenu", "UndeadOffRadar", $"{SelfStateOption.UndeadOffRadar}");
+        IniHelper.WriteValue("ExternalMenu", "NPCIgnore", $"{SelfStateOption.NPCIgnore}");
+        IniHelper.WriteValue("ExternalMenu", "PoliceIgnore", $"{SelfStateOption.PoliceIgnore}");
+
+        //快捷键
         IniHelper.WriteValue("ExternalMenu", "IsHotKeyToWaypoint", $"{SelfStateModel.IsHotKeyToWaypoint}");
         IniHelper.WriteValue("ExternalMenu", "IsHotKeyToObjective", $"{SelfStateModel.IsHotKeyToObjective}");
         IniHelper.WriteValue("ExternalMenu", "IsHotKeyFillHealthArmor", $"{SelfStateModel.IsHotKeyFillHealthArmor}");
@@ -137,6 +173,22 @@ public partial class SelfStateView : UserControl
 
         IniHelper.WriteValue("ExternalMenu", "IsHotKeyNoCollision", $"{SelfStateModel.IsHotKeyNoCollision}");
         IniHelper.WriteValue("ExternalMenu", "IsHotKeyToCrossHair", $"{SelfStateModel.IsHotKeyToCrossHair}");
+
+        //实用功能
+        IniHelper.WriteValue("ExternalMenu", "ClearWanted", $"{SelfStateOption.ClearWanted}");
+        IniHelper.WriteValue("ExternalMenu", "KillNPC", $"{SelfStateOption.KillNPC}");
+        IniHelper.WriteValue("ExternalMenu", "KillHostilityNPC", $"{SelfStateOption.KillHostilityNPC}");
+        IniHelper.WriteValue("ExternalMenu", "KillPolice", $"{SelfStateOption.KillPolice}");
+
+        //高级
+        IniHelper.WriteValue("ExternalMenu", "ProofBullet", $"{SelfStateOption.ProofBullet}");
+        IniHelper.WriteValue("ExternalMenu", "ProofFire", $"{SelfStateOption.ProofFire}");
+        IniHelper.WriteValue("ExternalMenu", "ProofCollision", $"{SelfStateOption.ProofCollision}");
+        IniHelper.WriteValue("ExternalMenu", "ProofMelee", $"{SelfStateOption.ProofMelee}");
+        IniHelper.WriteValue("ExternalMenu", "ProofExplosion", $"{SelfStateOption.ProofExplosion}");
+        IniHelper.WriteValue("ExternalMenu", "ProofSteam", $"{SelfStateOption.ProofSteam}");
+        IniHelper.WriteValue("ExternalMenu", "ProofDrown", $"{SelfStateOption.ProofDrown}");
+        IniHelper.WriteValue("ExternalMenu", "ProofWater", $"{SelfStateOption.ProofWater}");
     }
 
     /// <summary>
@@ -187,10 +239,10 @@ public partial class SelfStateView : UserControl
             case Keys.D0:
                 if (SelfStateModel.IsHotKeyNoCollision)
                 {
-                    _options.NoCollision = !_options.NoCollision;
-                    Player.NoCollision(_options.NoCollision);
+                    SelfStateOption.NoCollision = !SelfStateOption.NoCollision;
+                    Player.NoCollision(SelfStateOption.NoCollision);
 
-                    if (_options.NoCollision)
+                    if (SelfStateOption.NoCollision)
                         Console.Beep(600, 75);
                     else
                         Console.Beep(500, 75);
@@ -250,31 +302,31 @@ public partial class SelfStateView : UserControl
         ///////////////////////////////////////////////////
 
         // 玩家无敌
-        if (_options.GodMode)
+        if (SelfStateOption.GodMode)
             Player.GodMode(true);
         // 挂机防踢
-        if (_options.AntiAFK)
+        if (SelfStateOption.AntiAFK)
             Online.AntiAFK(true);
         // 无布娃娃
-        if (_options.NoRagdoll)
+        if (SelfStateOption.NoRagdoll)
             Player.NoRagdoll(true);
         // 雷达影踪（假死）
-        if (_options.UndeadOffRadar)
+        if (SelfStateOption.UndeadOffRadar)
             Player.UndeadOffRadar(true);
         // 玩家无碰撞体积
-        if (_options.NoCollision)
+        if (SelfStateOption.NoCollision)
             Player.NoCollision(true);
 
         // NPC无视、警察无视
-        if (_options.NPCIgnore == true && _options.PoliceIgnore == false)
+        if (SelfStateOption.NPCIgnore == true && SelfStateOption.PoliceIgnore == false)
         {
             Player.NPCIgnore(0x040000);
         }
-        else if (_options.NPCIgnore == false && _options.PoliceIgnore == true)
+        else if (SelfStateOption.NPCIgnore == false && SelfStateOption.PoliceIgnore == true)
         {
             Player.NPCIgnore(0xC30000);
         }
-        else if (_options.NPCIgnore == true && _options.PoliceIgnore == true)
+        else if (SelfStateOption.NPCIgnore == true && SelfStateOption.PoliceIgnore == true)
         {
             Player.NPCIgnore(0xC70000);
         }
@@ -282,36 +334,36 @@ public partial class SelfStateView : UserControl
         ///////////////////////////////////////////////////
 
         // 防子弹（防止子弹掉血）
-        if (_options.ProofBullet)
+        if (SelfStateOption.ProofBullet)
             Player.ProofBullet(true);
         // 防火烧（防止燃烧掉血）
-        if (_options.ProofFire)
+        if (SelfStateOption.ProofFire)
             Player.ProofFire(true);
         // 防撞击（防止撞击掉血）
-        if (_options.ProofCollision)
+        if (SelfStateOption.ProofCollision)
             Player.ProofCollision(true);
         // 防近战（防止近战掉血）
-        if (_options.ProofMelee)
+        if (SelfStateOption.ProofMelee)
             Player.ProofMelee(true);
 
         // 防爆炸（防止爆炸掉血）
-        if (_options.ProofExplosion)
+        if (SelfStateOption.ProofExplosion)
             Player.ProofExplosion(true);
         // 防蒸汽（具体场景未知）
-        if (_options.ProofSteam)
+        if (SelfStateOption.ProofSteam)
             Player.ProofSteam(true);
         // 防溺水（具体场景未知）
-        if (_options.ProofDrown)
+        if (SelfStateOption.ProofDrown)
             Player.ProofDrown(true);
         // 防海水（可以水下行走）
-        if (_options.ProofWater)
+        if (SelfStateOption.ProofWater)
             Player.ProofWater(true);
     }
 
     private void GTA5MenuWindow_LoopSpeedFastEvent()
     {
         // 自动消星
-        if (_options.ClearWanted)
+        if (SelfStateOption.ClearWanted)
             Player.WantedLevel((byte)WantedLevel.Level0);
 
         // Ped
@@ -331,11 +383,11 @@ public partial class SelfStateView : UserControl
                 continue;
 
             // 自动击杀NPC
-            if (_options.KillNPC)
+            if (SelfStateOption.KillNPC)
                 Memory.Write(pCPed + CPed.Health, 0.0f);
 
             // 自动击杀敌对NPC
-            if (_options.KillHostilityNPC)
+            if (SelfStateOption.KillHostilityNPC)
             {
                 var oHostility = Memory.Read<byte>(pCPed + CPed.Hostility);
                 if (oHostility > 0x01)
@@ -345,7 +397,7 @@ public partial class SelfStateView : UserControl
             }
 
             // 自动击杀警察
-            if (_options.KillPolice)
+            if (SelfStateOption.KillPolice)
             {
                 var ped_type = Memory.Read<int>(pCPed + CPed.Ragdoll);
                 ped_type = ped_type << 11 >> 25;
@@ -404,46 +456,46 @@ public partial class SelfStateView : UserControl
 
     private void CheckBox_PlayerGodMode_Click(object sender, RoutedEventArgs e)
     {
-        _options.GodMode = CheckBox_PlayerGodMode.IsChecked == true;
-        Player.GodMode(_options.GodMode);
+        SelfStateOption.GodMode = CheckBox_PlayerGodMode.IsChecked == true;
+        Player.GodMode(SelfStateOption.GodMode);
     }
 
     private void CheckBox_AntiAFK_Click(object sender, RoutedEventArgs e)
     {
-        _options.AntiAFK = CheckBox_AntiAFK.IsChecked == true;
-        Online.AntiAFK(_options.AntiAFK);
+        SelfStateOption.AntiAFK = CheckBox_AntiAFK.IsChecked == true;
+        Online.AntiAFK(SelfStateOption.AntiAFK);
     }
 
     private void CheckBox_NoRagdoll_Click(object sender, RoutedEventArgs e)
     {
-        _options.NoRagdoll = CheckBox_NoRagdoll.IsChecked == true;
-        Player.NoRagdoll(_options.NoRagdoll);
+        SelfStateOption.NoRagdoll = CheckBox_NoRagdoll.IsChecked == true;
+        Player.NoRagdoll(SelfStateOption.NoRagdoll);
     }
 
     private void CheckBox_UndeadOffRadar_Click(object sender, RoutedEventArgs e)
     {
-        _options.UndeadOffRadar = CheckBox_UndeadOffRadar.IsChecked == true;
-        Player.UndeadOffRadar(_options.UndeadOffRadar);
+        SelfStateOption.UndeadOffRadar = CheckBox_UndeadOffRadar.IsChecked == true;
+        Player.UndeadOffRadar(SelfStateOption.UndeadOffRadar);
     }
 
     private void CheckBox_NPCIgnore_Click(object sender, RoutedEventArgs e)
     {
-        _options.NPCIgnore = CheckBox_NPCIgnore.IsChecked == true;
-        _options.PoliceIgnore = CheckBox_PoliceIgnore.IsChecked == true;
+        SelfStateOption.NPCIgnore = CheckBox_NPCIgnore.IsChecked == true;
+        SelfStateOption.PoliceIgnore = CheckBox_PoliceIgnore.IsChecked == true;
 
-        if (_options.NPCIgnore == true && _options.PoliceIgnore == false)
+        if (SelfStateOption.NPCIgnore == true && SelfStateOption.PoliceIgnore == false)
         {
             Player.NPCIgnore(0x040000);
             return;
         }
 
-        if (_options.NPCIgnore == false && _options.PoliceIgnore == true)
+        if (SelfStateOption.NPCIgnore == false && SelfStateOption.PoliceIgnore == true)
         {
             Player.NPCIgnore(0xC30000);
             return;
         }
 
-        if (_options.NPCIgnore == true && _options.PoliceIgnore == true)
+        if (SelfStateOption.NPCIgnore == true && SelfStateOption.PoliceIgnore == true)
         {
             Player.NPCIgnore(0xC70000);
             return;
@@ -454,32 +506,32 @@ public partial class SelfStateView : UserControl
 
     private void CheckBox_AutoClearWanted_Click(object sender, RoutedEventArgs e)
     {
-        _options.ClearWanted = CheckBox_AutoClearWanted.IsChecked == true;
+        SelfStateOption.ClearWanted = CheckBox_AutoClearWanted.IsChecked == true;
         Player.WantedLevel((byte)WantedLevel.Level0);
     }
 
     private void CheckBox_AutoKillNPC_Click(object sender, RoutedEventArgs e)
     {
-        _options.KillNPC = CheckBox_AutoKillNPC.IsChecked == true;
+        SelfStateOption.KillNPC = CheckBox_AutoKillNPC.IsChecked == true;
         World.KillNPC(false);
     }
 
     private void CheckBox_AutoKillHostilityNPC_Click(object sender, RoutedEventArgs e)
     {
-        _options.KillHostilityNPC = CheckBox_AutoKillHostilityNPC.IsChecked == true;
+        SelfStateOption.KillHostilityNPC = CheckBox_AutoKillHostilityNPC.IsChecked == true;
         World.KillNPC(true);
     }
 
     private void CheckBox_AutoKillPolice_Click(object sender, RoutedEventArgs e)
     {
-        _options.KillPolice = CheckBox_AutoKillPolice.IsChecked == true;
+        SelfStateOption.KillPolice = CheckBox_AutoKillPolice.IsChecked == true;
         World.KillPolice();
     }
 
     private void CheckBox_NoCollision_Click(object sender, RoutedEventArgs e)
     {
-        _options.NoCollision = SelfStateModel.IsHotKeyNoCollision;
-        Player.NoCollision(_options.NoCollision);
+        SelfStateOption.NoCollision = SelfStateModel.IsHotKeyNoCollision;
+        Player.NoCollision(SelfStateOption.NoCollision);
     }
 
     private void Button_FillHealth_Click(object sender, RoutedEventArgs e)
@@ -533,49 +585,49 @@ public partial class SelfStateView : UserControl
 
     private void CheckBox_ProofBullet_Click(object sender, RoutedEventArgs e)
     {
-        _options.ProofBullet = CheckBox_ProofBullet.IsChecked == true;
-        Player.ProofBullet(_options.ProofBullet);
+        SelfStateOption.ProofBullet = CheckBox_ProofBullet.IsChecked == true;
+        Player.ProofBullet(SelfStateOption.ProofBullet);
     }
 
     private void CheckBox_ProofFire_Click(object sender, RoutedEventArgs e)
     {
-        _options.ProofFire = CheckBox_ProofFire.IsChecked == true;
-        Player.ProofFire(_options.ProofFire);
+        SelfStateOption.ProofFire = CheckBox_ProofFire.IsChecked == true;
+        Player.ProofFire(SelfStateOption.ProofFire);
     }
 
     private void CheckBox_ProofCollision_Click(object sender, RoutedEventArgs e)
     {
-        _options.ProofCollision = CheckBox_ProofCollision.IsChecked == true;
-        Player.ProofCollision(_options.ProofCollision);
+        SelfStateOption.ProofCollision = CheckBox_ProofCollision.IsChecked == true;
+        Player.ProofCollision(SelfStateOption.ProofCollision);
     }
 
     private void CheckBox_ProofMelee_Click(object sender, RoutedEventArgs e)
     {
-        _options.ProofMelee = CheckBox_ProofMelee.IsChecked == true;
-        Player.ProofMelee(_options.ProofMelee);
+        SelfStateOption.ProofMelee = CheckBox_ProofMelee.IsChecked == true;
+        Player.ProofMelee(SelfStateOption.ProofMelee);
     }
 
     private void CheckBox_ProofExplosion_Click(object sender, RoutedEventArgs e)
     {
-        _options.ProofExplosion = CheckBox_ProofExplosion.IsChecked == true;
-        Player.ProofExplosion(_options.ProofExplosion);
+        SelfStateOption.ProofExplosion = CheckBox_ProofExplosion.IsChecked == true;
+        Player.ProofExplosion(SelfStateOption.ProofExplosion);
     }
 
     private void CheckBox_ProofSteam_Click(object sender, RoutedEventArgs e)
     {
-        _options.ProofSteam = CheckBox_ProofSteam.IsChecked == true;
-        Player.ProofSteam(_options.ProofSteam);
+        SelfStateOption.ProofSteam = CheckBox_ProofSteam.IsChecked == true;
+        Player.ProofSteam(SelfStateOption.ProofSteam);
     }
 
     private void CheckBox_ProofDrown_Click(object sender, RoutedEventArgs e)
     {
-        _options.ProofDrown = CheckBox_ProofDrown.IsChecked == true;
-        Player.ProofDrown(_options.ProofDrown);
+        SelfStateOption.ProofDrown = CheckBox_ProofDrown.IsChecked == true;
+        Player.ProofDrown(SelfStateOption.ProofDrown);
     }
 
     private void CheckBox_ProofWater_Click(object sender, RoutedEventArgs e)
     {
-        _options.ProofWater = CheckBox_ProofWater.IsChecked == true;
-        Player.ProofWater(_options.ProofWater);
+        SelfStateOption.ProofWater = CheckBox_ProofWater.IsChecked == true;
+        Player.ProofWater(SelfStateOption.ProofWater);
     }
 }

--- a/GTA5Menu/Views/OnlineVehicle/VehicleOptionView.xaml
+++ b/GTA5Menu/Views/OnlineVehicle/VehicleOptionView.xaml
@@ -19,14 +19,17 @@
                     <CheckBox
                         x:Name="CheckBox_VehicleGodMode"
                         Click="CheckBox_VehicleGodMode_Click"
+                        IsChecked="{Binding VO_Options.GodMode, UpdateSourceTrigger=PropertyChanged}"
                         Content="载具无敌" />
                     <CheckBox
                         x:Name="CheckBox_VehicleSeatbelt"
                         Click="CheckBox_VehicleSeatbelt_Click"
+                        IsChecked="{Binding VO_Options.Seatbelt, UpdateSourceTrigger=PropertyChanged}"
                         Content="载具安全带" />
                     <CheckBox
                         x:Name="CheckBox_VehicleParachute"
                         Click="CheckBox_VehicleParachute_Click"
+                        IsChecked="{Binding VO_Options.Parachute, UpdateSourceTrigger=PropertyChanged}"
                         Content="载具降落伞" />
                 </WrapPanel>
                 <WrapPanel Margin="5,0,5,0">

--- a/GTA5Menu/Views/OnlineVehicle/VehicleOptionView.xaml.cs
+++ b/GTA5Menu/Views/OnlineVehicle/VehicleOptionView.xaml.cs
@@ -1,4 +1,5 @@
-﻿using GTA5Core.Features;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using GTA5Core.Features;
 using GTA5Core.GTA.Onlines;
 using GTA5Shared.Helper;
 
@@ -9,22 +10,24 @@ namespace GTA5Menu.Views.OnlineVehicle;
 /// </summary>
 public partial class VehicleOptionView : UserControl
 {
-    private class Options
+    public partial class Options : ObservableObject
     {
-        public bool GodMode = false;
-        public bool Seatbelt = false;
-        public bool Parachute = false;
+        [ObservableProperty] public bool godMode = false;
+        [ObservableProperty] public bool seatbelt = false;
+        [ObservableProperty] public bool parachute = false;
 
-        public bool Extra = false;
-        public short ExtraFlag = 0;
+        [ObservableProperty] public bool extra = false;
+        [ObservableProperty] public short extraFlag = 0;
     }
-    private readonly Options _options = new();
+    public Options VO_Options { get; set; } = new();
 
     public VehicleOptionView()
     {
         InitializeComponent();
         GTA5MenuWindow.WindowClosingEvent += GTA5MenuWindow_WindowClosingEvent;
         GTA5MenuWindow.LoopSpeedNormalEvent += GTA5MenuWindow_LoopSpeedNormalEvent;
+
+        ReadConfig();
 
         // 载具附加功能
         foreach (var item in OnlineData.VehicleExtras)
@@ -38,23 +41,38 @@ public partial class VehicleOptionView : UserControl
     {
         GTA5MenuWindow.WindowClosingEvent -= GTA5MenuWindow_WindowClosingEvent;
         GTA5MenuWindow.LoopSpeedNormalEvent -= GTA5MenuWindow_LoopSpeedNormalEvent;
+        SaveConfig();
+    }
+
+    private void ReadConfig()
+    {
+        VO_Options.GodMode = IniHelper.ReadValue("VehicleOption", "GodMode").Equals("True", StringComparison.OrdinalIgnoreCase);
+        VO_Options.Seatbelt = IniHelper.ReadValue("VehicleOption", "Seatbelt").Equals("True", StringComparison.OrdinalIgnoreCase);
+        VO_Options.Parachute = IniHelper.ReadValue("VehicleOption", "Parachute").Equals("True", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void SaveConfig()
+    {
+        IniHelper.WriteValue("VehicleOption", "GodMode", $"{VO_Options.GodMode}");
+        IniHelper.WriteValue("VehicleOption", "Seatbelt", $"{VO_Options.Seatbelt}");
+        IniHelper.WriteValue("VehicleOption", "Parachute", $"{VO_Options.Parachute}");
     }
 
     private void GTA5MenuWindow_LoopSpeedNormalEvent()
     {
         // 载具无敌
-        if (_options.GodMode)
+        if (VO_Options.GodMode)
             Vehicle.GodMode(true);
         // 载具安全带
-        if (_options.Seatbelt)
+        if (VO_Options.Seatbelt)
             Vehicle.Seatbelt(true);
         // 载具降落伞
-        if (_options.Parachute)
+        if (VO_Options.Parachute)
             Vehicle.Parachute(true);
 
         // 载具附加功能
-        if (_options.Extra)
-            Vehicle.Extras(_options.ExtraFlag);
+        if (VO_Options.Extra)
+            Vehicle.Extras(VO_Options.ExtraFlag);
     }
 
     /////////////////////////////////////////////////
@@ -64,31 +82,31 @@ public partial class VehicleOptionView : UserControl
         var index = ListBox_VehicleExtras.SelectedIndex;
         if (index == -1 || index == 0)
         {
-            _options.Extra = false;
+            VO_Options.Extra = false;
             return;
         }
 
-        _options.Extra = true;
-        _options.ExtraFlag = (short)OnlineData.VehicleExtras[index].Value;
-        Vehicle.Extras(_options.ExtraFlag);
+        VO_Options.Extra = true;
+        VO_Options.ExtraFlag = (short)OnlineData.VehicleExtras[index].Value;
+        Vehicle.Extras(VO_Options.ExtraFlag);
     }
 
     private void CheckBox_VehicleGodMode_Click(object sender, RoutedEventArgs e)
     {
-        _options.GodMode = CheckBox_VehicleGodMode.IsChecked == true;
-        Vehicle.GodMode(_options.GodMode);
+        VO_Options.GodMode = CheckBox_VehicleGodMode.IsChecked == true;
+        Vehicle.GodMode(VO_Options.GodMode);
     }
 
     private void CheckBox_VehicleSeatbelt_Click(object sender, RoutedEventArgs e)
     {
-        _options.Seatbelt = CheckBox_VehicleSeatbelt.IsChecked == true;
-        Vehicle.Seatbelt(_options.Seatbelt);
+        VO_Options.Seatbelt = CheckBox_VehicleSeatbelt.IsChecked == true;
+        Vehicle.Seatbelt(VO_Options.Seatbelt);
     }
 
     private void CheckBox_VehicleParachute_Click(object sender, RoutedEventArgs e)
     {
-        _options.Parachute = CheckBox_VehicleParachute.IsChecked == true;
-        Vehicle.Parachute(_options.Parachute);
+        VO_Options.Parachute = CheckBox_VehicleParachute.IsChecked == true;
+        Vehicle.Parachute(VO_Options.Parachute);
     }
 
     private void Button_FillVehicleHealth_Click(object sender, RoutedEventArgs e)

--- a/GTA5Menu/Views/OnlineWeapon/WeaponOptionView.xaml
+++ b/GTA5Menu/Views/OnlineWeapon/WeaponOptionView.xaml
@@ -33,18 +33,22 @@
                 <CheckBox
                     x:Name="CheckBox_FastReload"
                     Click="CheckBox_FastReload_Click"
+                    IsChecked="{Binding WO_Options.FastReload, UpdateSourceTrigger=PropertyChanged}"
                     Content="快速换弹" />
                 <CheckBox
                     x:Name="CheckBox_NoRecoil"
                     Click="CheckBox_NoRecoil_Click"
+                    IsChecked="{Binding WO_Options.NoRecoil, UpdateSourceTrigger=PropertyChanged}"
                     Content="无后坐力" />
                 <CheckBox
                     x:Name="CheckBox_NoSpread"
                     Click="CheckBox_NoSpread_Click"
+                    IsChecked="{Binding WO_Options.NoSpread, UpdateSourceTrigger=PropertyChanged}"
                     Content="无子弹扩散" />
                 <CheckBox
                     x:Name="CheckBox_LongRange"
                     Click="CheckBox_LongRange_Click"
+                    IsChecked="{Binding WO_Options.LongRange, UpdateSourceTrigger=PropertyChanged}"
                     Content="提升射程" />
             </WrapPanel>
             <!--  ////////////////  -->

--- a/GTA5Menu/Views/OnlineWeapon/WeaponOptionView.xaml.cs
+++ b/GTA5Menu/Views/OnlineWeapon/WeaponOptionView.xaml.cs
@@ -1,4 +1,5 @@
-﻿using GTA5Core.Features;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using GTA5Core.Features;
 using GTA5Core.GTA.Onlines;
 using GTA5Shared.Helper;
 
@@ -9,23 +10,25 @@ namespace GTA5Menu.Views.OnlineWeapon;
 /// </summary>
 public partial class WeaponOptionView : UserControl
 {
-    private class Options
+    public partial class Options : ObservableObject
     {
-        public bool AmmoModifier = false;
-        public byte AmmoModifierFlag = 0;
+        [ObservableProperty] public bool ammoModifier = false;
+        [ObservableProperty] public byte ammoModifierFlag = 0;
 
-        public bool FastReload = false;
-        public bool NoRecoil = false;
-        public bool NoSpread = false;
-        public bool LongRange = false;
+        [ObservableProperty] public bool fastReload = false;
+        [ObservableProperty] public bool noRecoil = false;
+        [ObservableProperty] public bool noSpread = false;
+        [ObservableProperty] public bool longRange = false;
     }
-    private readonly Options _options = new();
+    public Options WO_Options { get; set; } = new();
 
     public WeaponOptionView()
     {
         InitializeComponent();
         GTA5MenuWindow.WindowClosingEvent += GTA5MenuWindow_WindowClosingEvent;
         GTA5MenuWindow.LoopSpeedNormalEvent += GTA5MenuWindow_LoopSpeedNormalEvent;
+
+        ReadConfig();
 
         // 子弹类型
         foreach (var item in OnlineData.ImpactExplosions)
@@ -39,6 +42,24 @@ public partial class WeaponOptionView : UserControl
     {
         GTA5MenuWindow.WindowClosingEvent -= GTA5MenuWindow_WindowClosingEvent;
         GTA5MenuWindow.LoopSpeedNormalEvent -= GTA5MenuWindow_LoopSpeedNormalEvent;
+        SaveConfig();
+    }
+
+    private void ReadConfig()
+    {
+        WO_Options.FastReload = IniHelper.ReadValue("WeaponOption", "FastReload").Equals("True", StringComparison.OrdinalIgnoreCase);
+        WO_Options.NoRecoil = IniHelper.ReadValue("WeaponOption", "NoRecoil").Equals("True", StringComparison.OrdinalIgnoreCase);
+        WO_Options.NoSpread = IniHelper.ReadValue("WeaponOption", "NoSpread").Equals("True", StringComparison.OrdinalIgnoreCase);
+        WO_Options.LongRange = IniHelper.ReadValue("WeaponOption", "LongRange").Equals("True", StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    private void SaveConfig()
+    {
+        IniHelper.WriteValue("WeaponOption", "FastReload", $"{WO_Options.FastReload}");
+        IniHelper.WriteValue("WeaponOption", "NoRecoil", $"{WO_Options.NoRecoil}");
+        IniHelper.WriteValue("WeaponOption", "NoSpread", $"{WO_Options.NoSpread}");
+        IniHelper.WriteValue("WeaponOption", "LongRange", $"{WO_Options.LongRange}");
     }
 
     /////////////////////////////////////////////////////
@@ -46,20 +67,20 @@ public partial class WeaponOptionView : UserControl
     private void GTA5MenuWindow_LoopSpeedNormalEvent()
     {
         // 弹药编辑
-        if (_options.AmmoModifier)
-            Weapon.AmmoModifier(_options.AmmoModifierFlag);
+        if (WO_Options.AmmoModifier)
+            Weapon.AmmoModifier(WO_Options.AmmoModifierFlag);
 
         // 快速换弹
-        if (_options.FastReload)
+        if (WO_Options.FastReload)
             Weapon.FastReload(true);
         // 无后坐力
-        if (_options.NoRecoil)
+        if (WO_Options.NoRecoil)
             Weapon.NoRecoil();
         // 无子弹扩散
-        if (_options.NoSpread)
+        if (WO_Options.NoSpread)
             Weapon.NoSpread();
         // 提升射程
-        if (_options.LongRange)
+        if (WO_Options.LongRange)
             Weapon.LongRange();
     }
 
@@ -71,13 +92,13 @@ public partial class WeaponOptionView : UserControl
         var index = ListBox_AmmoModifier.SelectedIndex;
         if (index == -1 || index == 0)
         {
-            _options.AmmoModifier = false;
+            WO_Options.AmmoModifier = false;
             return;
         }
 
-        _options.AmmoModifier = true;
-        _options.AmmoModifierFlag = (byte)(index - 1);
-        Weapon.AmmoModifier(_options.AmmoModifierFlag);
+        WO_Options.AmmoModifier = true;
+        WO_Options.AmmoModifierFlag = (byte)(index - 1);
+        Weapon.AmmoModifier(WO_Options.AmmoModifierFlag);
     }
 
     /// <summary>
@@ -109,25 +130,25 @@ public partial class WeaponOptionView : UserControl
 
     private void CheckBox_FastReload_Click(object sender, RoutedEventArgs e)
     {
-        _options.FastReload = CheckBox_FastReload.IsChecked == true;
-        Weapon.FastReload(_options.FastReload);
+        WO_Options.FastReload = CheckBox_FastReload.IsChecked == true;
+        Weapon.FastReload(WO_Options.FastReload);
     }
 
     private void CheckBox_NoRecoil_Click(object sender, RoutedEventArgs e)
     {
-        _options.NoRecoil = CheckBox_NoRecoil.IsChecked == true;
+        WO_Options.NoRecoil = CheckBox_NoRecoil.IsChecked == true;
         Weapon.NoRecoil();
     }
 
     private void CheckBox_NoSpread_Click(object sender, RoutedEventArgs e)
     {
-        _options.NoSpread = CheckBox_NoSpread.IsChecked == true;
+        WO_Options.NoSpread = CheckBox_NoSpread.IsChecked == true;
         Weapon.NoSpread();
     }
 
     private void CheckBox_LongRange_Click(object sender, RoutedEventArgs e)
     {
-        _options.LongRange = CheckBox_LongRange.IsChecked == true;
+        WO_Options.LongRange = CheckBox_LongRange.IsChecked == true;
         Weapon.LongRange();
     }
 


### PR DESCRIPTION
把Option从private 改成了 public
然后按照SelfStateModel加了ObservableObject和ObservableProperty
在xaml设置了绑定，都是类似热键写的
把_option 改名了，不然一直爆提示。。。
在OnlineOption里增加了设置 统一了按下事件的写法
只保存了checkbox的内容，载具的 附加功能 和武器的 弹药编辑，子弹类型 没有保存

