### PR TITLE
1.69-3258更新 part1

### DIFF
--- a/GTA5Core/Features/Globals.cs
+++ b/GTA5Core/Features/Globals.cs
@@ -66,7 +66,7 @@ public static class Globals
     /// <returns></returns>
     public static bool IsOnlineMode()
     {
-        return Get_Global_Value<int>(114372 + 2366 + 539 + 4321) == 145;
+        return Get_Global_Value<int>(113969 + 2366 + 539 + 4321) == 145;
     }
 
     /// <summary>
@@ -75,7 +75,7 @@ public static class Globals
     /// <returns></returns>
     public static int GetNetworkTime()
     {
-        return Get_Global_Value<int>(1574764 + 11);
+        return Get_Global_Value<int>(1574765 + 11);
     }
 
     /// <summary>
@@ -93,7 +93,7 @@ public static class Globals
     /// <returns></returns>
     public static int GetPlayerIndex()
     {
-        return Get_Global_Value<int>(1574925);
+        return Get_Global_Value<int>(1574926);
     }
 
     /// <summary>
@@ -122,13 +122,13 @@ public static class Globals
 
             Vector3 vector3 = Teleport.GetPlayerPosition();
 
-            Set_Global_Value(2707016 + 3, vector3.X);
-            Set_Global_Value(2707016 + 4, vector3.Y);
-            Set_Global_Value(2707016 + 5, vector3.Z + 3.0f);
-            Set_Global_Value(2707016 + 1, 9999);
+            Set_Global_Value(2707336 + 3, vector3.X);
+            Set_Global_Value(2707336 + 4, vector3.Y);
+            Set_Global_Value(2707336 + 5, vector3.Z + 3.0f);
+            Set_Global_Value(2707336 + 1, 9999);
 
-            Set_Global_Value(4535851 + 1 + Get_Global_Value<int>(2707016) * 85 + 66 + 2, 2);
-            Set_Global_Value(2707016 + 6, 1);
+            Set_Global_Value(4535950 + 1 + Get_Global_Value<int>(2707336) * 85 + 66 + 2, 2);
+            Set_Global_Value(2707336 + 6, 1);
 
             await Task.Delay(200);
 

--- a/GTA5Core/Features/Online.cs
+++ b/GTA5Core/Features/Online.cs
@@ -63,15 +63,15 @@ public static class Online
     public static void AntiAFK(bool isEnable)
     {
         // STATS::PLAYSTATS_IDLE_KICK
-        Globals.Set_Global_Value(Base.Default + 87, isEnable ? 99999999 : 120000);        // 120000     joaat("IDLEKICK_WARNING1") 
-        Globals.Set_Global_Value(Base.Default + 88, isEnable ? 99999999 : 300000);        // 300000     joaat("IDLEKICK_WARNING2")
-        Globals.Set_Global_Value(Base.Default + 89, isEnable ? 99999999 : 600000);        // 600000     joaat("IDLEKICK_WARNING3")
-        Globals.Set_Global_Value(Base.Default + 90, isEnable ? 99999999 : 900000);        // 900000     joaat("IDLEKICK_KICK")
+        Globals.Set_Global_Value(Base.Default + 84, isEnable ? 99999999 : 120000);        // 120000     joaat("IDLEKICK_WARNING1") 
+        Globals.Set_Global_Value(Base.Default + 85, isEnable ? 99999999 : 300000);        // 300000     joaat("IDLEKICK_WARNING2")
+        Globals.Set_Global_Value(Base.Default + 86, isEnable ? 99999999 : 600000);        // 600000     joaat("IDLEKICK_WARNING3")
+        Globals.Set_Global_Value(Base.Default + 87, isEnable ? 99999999 : 900000);        // 900000     joaat("IDLEKICK_KICK")
 
-        Globals.Set_Global_Value(Base.Default + 8426, isEnable ? 2000000000 : 30000);     // 30000      joaat("ConstrainedKick_Warning1")
-        Globals.Set_Global_Value(Base.Default + 8427, isEnable ? 2000000000 : 60000);     // 60000      joaat("ConstrainedKick_Warning2")
-        Globals.Set_Global_Value(Base.Default + 8428, isEnable ? 2000000000 : 90000);     // 90000      joaat("ConstrainedKick_Warning3")
-        Globals.Set_Global_Value(Base.Default + 8429, isEnable ? 2000000000 : 120000);    // 120000     joaat("ConstrainedKick_Kick")
+        Globals.Set_Global_Value(Base.Default + 8413, isEnable ? 2000000000 : 30000);     // 30000      joaat("ConstrainedKick_Warning1")
+        Globals.Set_Global_Value(Base.Default + 8414, isEnable ? 2000000000 : 60000);     // 60000      joaat("ConstrainedKick_Warning2")
+        Globals.Set_Global_Value(Base.Default + 8415, isEnable ? 2000000000 : 90000);     // 90000      joaat("ConstrainedKick_Warning3")
+        Globals.Set_Global_Value(Base.Default + 8416, isEnable ? 2000000000 : 120000);    // 120000     joaat("ConstrainedKick_Kick")
     }
 
     /// <summary>
@@ -80,7 +80,7 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void FreeChangeAppearance(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.Default + 19320, isEnable ? 0 : 100000);         // joaat("CHARACTER_APPEARANCE_CHARGE")
+        Globals.Set_Global_Value(Base.Default + 18918, isEnable ? 0 : 100000);         // joaat("CHARACTER_APPEARANCE_CHARGE")
     }
 
     /// <summary>
@@ -89,7 +89,7 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void ChangeAppearanceCooldown(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.Default + 19321, isEnable ? 0 : 2880000);         // joaat("CHARACTER_APPEARANCE_COOLDOWN")
+        Globals.Set_Global_Value(Base.Default + 18919, isEnable ? 0 : 2880000);         // joaat("CHARACTER_APPEARANCE_COOLDOWN")
     }
 
     /// <summary>
@@ -111,7 +111,7 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void SellOnNonPublic(bool isEnable)
     {
-        Globals.Set_Global_Value(2684312 + 744, isEnable ? 0 : 1);         // NETWORK::NETWORK_SESSION_GET_PRIVATE_SLOTS()
+        Globals.Set_Global_Value(2684504 + 746, isEnable ? 0 : 1);         // NETWORK::NETWORK_SESSION_GET_PRIVATE_SLOTS()
     }
 
     /// <summary>
@@ -120,7 +120,7 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void PassiveModeCooldown(bool isEnable)
     {
-        Globals.Set_Global_Value(2738587 + 4497, isEnable ? 0 : 1);        // AUDIO::REQUEST_SCRIPT_AUDIO_BANK("DLC_HEI4/DLC_HEI4_Submarine" // _STOPWATCH_RESET(&(Global_2794162.f_4497), false, false);
+        Globals.Set_Global_Value(2738934 + 4512, isEnable ? 0 : 1);        // AUDIO::REQUEST_SCRIPT_AUDIO_BANK("DLC_HEI4/DLC_HEI4_Submarine" // _STOPWATCH_RESET(&(Global_2794162.f_4497), false, false);
         Globals.Set_Global_Value(1963748, isEnable ? 0 : 1);               // joaat("VEHICLE_WEAPON_SUB_MISSILE_HOMING")
     }
 
@@ -131,10 +131,10 @@ public static class Online
     public static void SuicideCooldown(bool isEnable)
     {
         if (isEnable)
-            Globals.Set_Global_Value(Base.oVMYCar + 6937, 0);      // joaat("XPCATEGORY_ACTION_KILLS")
+            Globals.Set_Global_Value(Base.oVMYCar + 6975, 0);      // joaat("XPCATEGORY_ACTION_KILLS")
 
-        Globals.Set_Global_Value(Base.Default + 28685, isEnable ? 1 : 300000);         // 247954694
-        Globals.Set_Global_Value(Base.Default + 28686, isEnable ? 1 : 60000);          // -1771488297
+        Globals.Set_Global_Value(Base.Default + 27968, isEnable ? 1 : 300000);         // 247954694
+        Globals.Set_Global_Value(Base.Default + 27969, isEnable ? 1 : 60000);          // -1771488297
     }
 
     /// <summary>

--- a/GTA5Core/Features/Online.cs
+++ b/GTA5Core/Features/Online.cs
@@ -99,10 +99,10 @@ public static class Online
     public static async void ModelChange(long hash)
     {
         // else if (!PED::HAS_PED_HEAD_BLEND_FINISHED(PLAYER::PLAYER_PED_ID())
-        Globals.Set_Global_Value(Base.oVGETIn + 62, 1);                 // triggerModelChange
-        Globals.Set_Global_Value(Base.oVGETIn + 49, hash);              // modelChangeHash
+        Globals.Set_Global_Value(Base.oVGETIn + 63, 1);                 // triggerModelChange
+        Globals.Set_Global_Value(Base.oVGETIn + 50, hash);              // modelChangeHash
         await Task.Delay(10);
-        Globals.Set_Global_Value(Base.oVGETIn + 62, 0);
+        Globals.Set_Global_Value(Base.oVGETIn + 63, 0);
     }
 
     /// <summary>

--- a/GTA5Core/Features/Online.cs
+++ b/GTA5Core/Features/Online.cs
@@ -143,7 +143,7 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void OrbitalCooldown(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.Default + 23294, isEnable ? 0 : 2880000);         // -1707434973
+        Globals.Set_Global_Value(Base.Default + 22732, isEnable ? 0 : 2880000);         // -1707434973
     }
 
     /// <summary>
@@ -160,7 +160,7 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void SessionSnow(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.Default + 4575, isEnable ? 1 : 0);            // joaat("turn_snow_on_off")
+        Globals.Set_Global_Value(Base.Default + 4413, isEnable ? 1 : 0);            // joaat("turn_snow_on_off")
     }
 
     /// <summary>
@@ -169,12 +169,12 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void OffRadar(bool isEnable)
     {
-        // Global_2657704[PLAYER::PLAYER_ID() /*463*/].f_210
+        // Global_2657971[PLAYER::PLAYER_ID() /*465*/].f_211 = 0;
         // timeDifference = NETWORK::GET_TIME_DIFFERENCE(NETWORK::GET_NETWORK_TIME(), Global_2672524.f_57);
-        Globals.Set_Global_Value(Base.oPlayerIDHelp + 1 + Globals.GetPlayerID() * 463 + 210, isEnable ? 1 : 0);
+        Globals.Set_Global_Value(Base.oPlayerIDHelp + 1 + Globals.GetPlayerID() * 465 + 211, isEnable ? 1 : 0);
         if (isEnable)
             Globals.Set_Global_Value(Base.oNETTimeHelp + 58, Globals.GetNetworkTime() + 3600000);
-        Globals.Set_Global_Value(Base.oVMYCar + 4667, isEnable ? 3 : 0);
+        Globals.Set_Global_Value(Base.oVMYCar + 4682, isEnable ? 3 : 0);
     }
 
     /// <summary>
@@ -183,10 +183,10 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void GhostOrganization(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.oPlayerIDHelp + 1 + Globals.GetPlayerID() * 463 + 210, isEnable ? 1 : 0);
+        Globals.Set_Global_Value(Base.oPlayerIDHelp + 1 + Globals.GetPlayerID() * 465 + 211, isEnable ? 1 : 0);
         if (isEnable)
             Globals.Set_Global_Value(Base.oNETTimeHelp + 58, Globals.GetNetworkTime() + 3600000);        // iVar0 = NETWORK::GET_TIME_DIFFERENCE(NETWORK::GET_NETWORK_TIME()
-        Globals.Set_Global_Value(Base.oVMYCar + 4667, isEnable ? 4 : 0);
+        Globals.Set_Global_Value(Base.oVMYCar + 4682, isEnable ? 4 : 0);
     }
 
     /// <summary>
@@ -195,9 +195,9 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void BribeOrBlindCops(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.oVMYCar + 4661 + 1, isEnable ? 1 : 0);           // _DISPLAY_HELP_TEXT("FM_LEST_NCPW"
-        Globals.Set_Global_Value(Base.oVMYCar + 4661 + 3, isEnable ? Globals.GetNetworkTime() + 3600000 : 0);
-        Globals.Set_Global_Value(Base.oVMYCar + 4661, isEnable ? 5 : 0);
+        Globals.Set_Global_Value(Base.oVMYCar + 4676 + 1, isEnable ? 1 : 0);           // _DISPLAY_HELP_TEXT("FM_LEST_NCPW"
+        Globals.Set_Global_Value(Base.oVMYCar + 4676 + 3, isEnable ? Globals.GetNetworkTime() + 3600000 : 0);
+        Globals.Set_Global_Value(Base.oVMYCar + 4676, isEnable ? 5 : 0);
     }
 
     /// <summary>
@@ -206,9 +206,9 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void BribeAuthorities(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.oVMYCar + 4661 + 1, isEnable ? 1 : 0);
-        Globals.Set_Global_Value(Base.oVMYCar + 4661 + 3, isEnable ? Globals.GetNetworkTime() + 3600000 : 0);
-        Globals.Set_Global_Value(Base.oVMYCar + 4661, isEnable ? 21 : 0);
+        Globals.Set_Global_Value(Base.oVMYCar + 4676 + 1, isEnable ? 1 : 0);
+        Globals.Set_Global_Value(Base.oVMYCar + 4676 + 3, isEnable ? Globals.GetNetworkTime() + 3600000 : 0);
+        Globals.Set_Global_Value(Base.oVMYCar + 4676, isEnable ? 21 : 0);
     }
 
     /// <summary>
@@ -217,7 +217,7 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void RevealPlayers(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.oPlayerIDHelp + 1 + Globals.GetPlayerID() * 463 + 213, isEnable ? 1 : 0);
+        Globals.Set_Global_Value(Base.oPlayerIDHelp + 1 + Globals.GetPlayerID() * 465 + 214, isEnable ? 1 : 0);
         Globals.Set_Global_Value(Base.oNETTimeHelp + 59, isEnable ? Globals.GetNetworkTime() + 3600000 : 0);
     }
 
@@ -236,7 +236,7 @@ public static class Online
     /// <param name="multiplier"></param>
     public static void APMultiplier(float multiplier)
     {
-        Globals.Set_Global_Value(Base.Default + 26184, multiplier);      // joaat("AP_MULTIPLIER")
+        Globals.Set_Global_Value(Base.Default + 25490, multiplier);      // joaat("AP_MULTIPLIER")
     }
 
     /// <summary>
@@ -245,14 +245,14 @@ public static class Online
     /// <param name="multiplier"></param>
     public static void REPMultiplier(float multiplier)
     {
-        Globals.Set_Global_Value(Base.Default + 31966, multiplier);        // Street Race         街头比赛        -147149995  joaat("TUNER_STREET_RACE_PLACE_XP_MULTIPLIER")
-        Globals.Set_Global_Value(Base.Default + 31967, multiplier);        // Pursuit Race        追逐赛
-        Globals.Set_Global_Value(Base.Default + 31968, multiplier);        // Scramble            攀登
-        Globals.Set_Global_Value(Base.Default + 31969, multiplier);        // Head 2 Head         头对头          1434998920
+        Globals.Set_Global_Value(Base.Default + 30980, multiplier);        // Street Race         街头比赛        -147149995  joaat("TUNER_STREET_RACE_PLACE_XP_MULTIPLIER")
+        Globals.Set_Global_Value(Base.Default + 30981, multiplier);        // Pursuit Race        追逐赛
+        Globals.Set_Global_Value(Base.Default + 30982, multiplier);        // Scramble            攀登
+        Globals.Set_Global_Value(Base.Default + 30983, multiplier);        // Head 2 Head         头对头          1434998920
 
-        Globals.Set_Global_Value(Base.Default + 31971, multiplier);        // LS Car Meet         汽车见面会       1819417801  joaat("TUNER_CARCLUB_TIME_XP_MULTIPLIER")
-        Globals.Set_Global_Value(Base.Default + 31972, multiplier);        // LS Car Meet Track
-        Globals.Set_Global_Value(Base.Default + 31973, multiplier);        // LS Car Meet Cloth Shop
+        Globals.Set_Global_Value(Base.Default + 30985, multiplier);        // LS Car Meet         汽车见面会       1819417801  joaat("TUNER_CARCLUB_TIME_XP_MULTIPLIER")
+        Globals.Set_Global_Value(Base.Default + 30986, multiplier);        // LS Car Meet Track
+        Globals.Set_Global_Value(Base.Default + 30987, multiplier);        // LS Car Meet Cloth Shop
     }
 
     /// <summary>
@@ -262,12 +262,12 @@ public static class Online
     public static void InstantBullShark(bool isEnable)
     {
         if (isEnable)
-            Globals.Set_Global_Value(Base.oNETTimeHelp + 3694, 1);
+            Globals.Set_Global_Value(Base.oNETTimeHelp + 3733, 1);
         else
         {
-            var temp = Globals.Get_Global_Value<int>(Base.oNETTimeHelp + 3694);
+            var temp = Globals.Get_Global_Value<int>(Base.oNETTimeHelp + 3733);
             if (temp != 0)
-                Globals.Set_Global_Value(Base.oNETTimeHelp + 3694, 5);
+                Globals.Set_Global_Value(Base.oNETTimeHelp + 3733, 5);
         }
     }
 
@@ -277,7 +277,7 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void CallBackupHeli(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.oVMYCar + 4491, isEnable ? 1 : 0);   // SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH(joaat("am_backup_heli")
+        Globals.Set_Global_Value(Base.oVMYCar + 4506, isEnable ? 1 : 0);   // SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH(joaat("am_backup_heli")
     }
 
     /// <summary>
@@ -286,7 +286,7 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void CallAirstrike(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.oVMYCar + 4492, isEnable ? 1 : 0);   // SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH(joaat("am_airstrike")
+        Globals.Set_Global_Value(Base.oVMYCar + 4507, isEnable ? 1 : 0);   // SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH(joaat("am_airstrike")
     }
 
     /// <summary>
@@ -295,7 +295,7 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void CEOSpecialCargo(bool isEnable)
     {
-        Globals.Set_Global_Value(1942640, isEnable ? 1 : 0);           // MISC::GET_RANDOM_INT_IN_RANGE(1, 101);   // Global_1950703 = 1;
+        Globals.Set_Global_Value(1943379, isEnable ? 1 : 0);           // MISC::GET_RANDOM_INT_IN_RANGE(1, 101);   // Global_1950703 = 1;
     }
 
     /// <summary>
@@ -304,7 +304,7 @@ public static class Online
     /// <param name="cargoID"></param>
     public static void CEOCargoType(int cargoID)
     {
-        Globals.Set_Global_Value(1942486, cargoID);                    // MISC::GET_RANDOM_INT_IN_RANGE(1, 101);   // Global_1950549 = num;
+        Globals.Set_Global_Value(1943225, cargoID);                    // MISC::GET_RANDOM_INT_IN_RANGE(1, 101);   // Global_1950549 = num;
     }
 
     /// <summary>
@@ -313,7 +313,7 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void CEOBuyingCratesCooldown(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.Default + 15756, isEnable ? 0 : 300000);          // 153204142 joaat("EXEC_BUY_COOLDOWN")
+        Globals.Set_Global_Value(Base.Default + 15499, isEnable ? 0 : 300000);          // 153204142 joaat("EXEC_BUY_COOLDOWN")
     }
 
     /// <summary>
@@ -322,7 +322,7 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void CEOSellingCratesCooldown(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.Default + 15757, isEnable ? 0 : 1800000);         // 1291620941 joaat("EXEC_SELL_COOLDOWN")
+        Globals.Set_Global_Value(Base.Default + 15500, isEnable ? 0 : 1800000);         // 1291620941 joaat("EXEC_SELL_COOLDOWN")
     }
 
     /// <summary>
@@ -331,11 +331,11 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void BunkerSupplyDelay(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.Default + 21767, isEnable ? 0 : 600);            // -2094564985 joaat("GR_PURCHASE_SUPPLIES_DELAY")
+        Globals.Set_Global_Value(Base.Default + 21274, isEnable ? 0 : 600);            // -2094564985 joaat("GR_PURCHASE_SUPPLIES_DELAY")
     }
 
     /// <summary>
-    /// 解锁地堡所有研究 (临时)
+    /// 解锁地堡所有研究 (临时) //TODO: find a new way or remove it
     /// </summary>
     /// <param name="isEnable"></param>
     public static void UnlockBunkerResearch(bool isEnable)
@@ -349,7 +349,7 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void MCSupplyDelay(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.Default + 19209, isEnable ? 0 : 600);          // 728170457  joaat("WEBSITE_PEGASSI_FAGGIO_SPORT")
+        Globals.Set_Global_Value(Base.Default + 18809, isEnable ? 0 : 600);          // 728170457  joaat("WEBSITE_PEGASSI_FAGGIO_SPORT")
     }
 
     /// <summary>
@@ -367,10 +367,10 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void ExportVehicleDelay(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.Default + 19892, isEnable ? 0 : 1200000);        // 1001423248  tuneables_processing.c
-        Globals.Set_Global_Value(Base.Default + 19893, isEnable ? 0 : 1680000);        // 240134765
-        Globals.Set_Global_Value(Base.Default + 19894, isEnable ? 0 : 2340000);        // 1915379148
-        Globals.Set_Global_Value(Base.Default + 19895, isEnable ? 0 : 2880000);        // -824005590
+        Globals.Set_Global_Value(Base.Default + 19432, isEnable ? 0 : 1200000);        // 1001423248  tuneables_processing.c
+        Globals.Set_Global_Value(Base.Default + 19433, isEnable ? 0 : 1680000);        // 240134765
+        Globals.Set_Global_Value(Base.Default + 19434, isEnable ? 0 : 2340000);        // 1915379148
+        Globals.Set_Global_Value(Base.Default + 19435, isEnable ? 0 : 2880000);        // -824005590
     }
 
     /// <summary>
@@ -378,9 +378,9 @@ public static class Online
     /// </summary>
     public static async void Disconnect()
     {
-        Globals.Set_Global_Value(33106, 1);              // NETWORK::NETWORK_BAIL(1, 0, 0)
+        Globals.Set_Global_Value(33226, 1);              // NETWORK::NETWORK_BAIL(1, 0, 0)
         await Task.Delay(200);
-        Globals.Set_Global_Value(33106, 0);              // return NETWORK::NETWORK_CAN_ACCESS_MULTIPLAYER
+        Globals.Set_Global_Value(33226, 0);              // return NETWORK::NETWORK_CAN_ACCESS_MULTIPLAYER
     }
 
     /// <summary>
@@ -388,11 +388,11 @@ public static class Online
     /// </summary>
     public static async void StopCutscene()
     {
-        Globals.Set_Global_Value(2710132 + 3, 1);        // return MISC::GET_HASH_KEY("AVISA")
-        Globals.Set_Global_Value(1575079, 1);            // NETWORK::NETWORK_TRANSITION_ADD_STAGE(hashKey, 1, num, etsParam0, 0);
+        Globals.Set_Global_Value(2710447 + 3, 1);        // CUTSCENE::REQUEST_CUTSCENE("HS4_SCP_KNCK", 8);
+        Globals.Set_Global_Value(1575083, 1);            // NETWORK::NETWORK_TRANSITION_ADD_STAGE(hashKey, 1, num, etsParam0, 0);
         await Task.Delay(1000);
-        Globals.Set_Global_Value(2710132 + 3, 0);
-        Globals.Set_Global_Value(1575079, 0);
+        Globals.Set_Global_Value(2710447 + 3, 0);
+        Globals.Set_Global_Value(1575083, 0);
     }
 
     /// <summary>
@@ -401,10 +401,10 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void SmugglerRunInDelay(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.Default + 22961, isEnable ? 0 : 120000);         // 1278611667  tuneables_processing.c
-        Globals.Set_Global_Value(Base.Default + 22962, isEnable ? 0 : 180000);         // -1424847540
-        Globals.Set_Global_Value(Base.Default + 22963, isEnable ? 0 : 240000);         // -1817541754
-        Globals.Set_Global_Value(Base.Default + 22964, isEnable ? 0 : 60000);          // 1722502526
+        Globals.Set_Global_Value(Base.Default + 22433, isEnable ? 0 : 120000);         // 1278611667  tuneables_processing.c
+        Globals.Set_Global_Value(Base.Default + 22434, isEnable ? 0 : 180000);         // -1424847540
+        Globals.Set_Global_Value(Base.Default + 22435, isEnable ? 0 : 240000);         // -1817541754
+        Globals.Set_Global_Value(Base.Default + 22436, isEnable ? 0 : 60000);          // 1722502526
     }
 
     /// <summary>
@@ -413,7 +413,7 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void SmugglerRunOutDelay(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.Default + 23002, isEnable ? 0 : 180000);         // -1525481945  tuneables_processing.c
+        Globals.Set_Global_Value(Base.Default + 22474, isEnable ? 0 : 180000);         // -1525481945  tuneables_processing.c
     }
 
     /// <summary>
@@ -422,9 +422,9 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void NightclubOutDelay(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.Default + 24659, isEnable ? 0 : 300000);         // 1763921019  tuneables_processing.c
-        Globals.Set_Global_Value(Base.Default + 24701, isEnable ? 0 : 300000);         // -1004589438  Global_262145.f_24671 = 300000;
-        Globals.Set_Global_Value(Base.Default + 24702, isEnable ? 0 : 300000);         // 464940095
+        Globals.Set_Global_Value(Base.Default + 24026, isEnable ? 0 : 300000);         // 1763921019  tuneables_processing.c
+        Globals.Set_Global_Value(Base.Default + 24067, isEnable ? 0 : 300000);         // -1004589438  Global_262145.f_24671 = 300000;
+        Globals.Set_Global_Value(Base.Default + 24068, isEnable ? 0 : 300000);         // 464940095
     }
 
     /// <summary>
@@ -434,9 +434,9 @@ public static class Online
     public static void CEOWorkCooldown(bool isEnable)
     {
         // CEO工作
-        Globals.Set_Global_Value(Base.Default + 13281, isEnable ? 0 : 300000);       // -1404265088 joaat("GB_COOLDOWN_UNTIL_NEXT_BOSS_WORK")
+        Globals.Set_Global_Value(Base.Default + 13059, isEnable ? 0 : 300000);       // -1404265088 joaat("GB_COOLDOWN_UNTIL_NEXT_BOSS_WORK")
         // 观光客
-        Globals.Set_Global_Value(Base.Default + 13178, isEnable ? 0 : 600000);       // -1911318106 joaat("GB_SIGHTSEER_COOLDOWN")
+        Globals.Set_Global_Value(Base.Default + 12956, isEnable ? 0 : 600000);       // -1911318106 joaat("GB_SIGHTSEER_COOLDOWN")
     }
 
     /// <summary>
@@ -445,11 +445,11 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void ClientJobCooldown(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.Default + 24848 + 0, isEnable ? 0 : 300000);       // Between Jobs           -926426916
-        Globals.Set_Global_Value(Base.Default + 24848 + 1, isEnable ? 0 : 1800000);      // Robbery in Progress    1733390598
-        Globals.Set_Global_Value(Base.Default + 24848 + 2, isEnable ? 0 : 1800000);      // Data Sweep             724724668
-        Globals.Set_Global_Value(Base.Default + 24848 + 3, isEnable ? 0 : 1800000);      // Targeted Data          846317886
-        Globals.Set_Global_Value(Base.Default + 24848 + 4, isEnable ? 0 : 1800000);      // Diamond Shopping       443623246
+        Globals.Set_Global_Value(Base.Default + 24208 + 0, isEnable ? 0 : 300000);       // Between Jobs           -926426916
+        Globals.Set_Global_Value(Base.Default + 24208 + 1, isEnable ? 0 : 1800000);      // Robbery in Progress    1733390598
+        Globals.Set_Global_Value(Base.Default + 24208 + 2, isEnable ? 0 : 1800000);      // Data Sweep             724724668
+        Globals.Set_Global_Value(Base.Default + 24208 + 3, isEnable ? 0 : 1800000);      // Targeted Data          846317886
+        Globals.Set_Global_Value(Base.Default + 24208 + 4, isEnable ? 0 : 1800000);      // Diamond Shopping       443623246
     }
 
     /// <summary>
@@ -458,7 +458,7 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void SecurityHitCooldown(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.Default + 32024, isEnable ? 0 : 300000);           // -1462622971 joaat("FIXER_SECURITY_CONTRACT_COOLDOWN_TIME")
+        Globals.Set_Global_Value(Base.Default + 31038, isEnable ? 0 : 300000);           // -1462622971 joaat("FIXER_SECURITY_CONTRACT_COOLDOWN_TIME")
     }
 
     /// <summary>
@@ -467,7 +467,7 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void PayphoneHitCooldown(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.Default + 32105, isEnable ? 0 : 1200000);          // 1872071131
+        Globals.Set_Global_Value(Base.Default + 31118, isEnable ? 0 : 1200000);          // 1872071131
     }
 
     /// <summary>
@@ -476,7 +476,7 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void TriggerRCBandito(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.oVMYCar + 6918, isEnable ? 1 : 0);                 // if (PED::IS_PED_IN_ANY_VEHICLE(PLAYER::PLAYER_PED_ID(), true) || PED::IS_PED_GETTING_INTO_A_VEHICLE(PLAYER::PLAYER_PED_ID()))
+        Globals.Set_Global_Value(Base.oVMYCar + 6956, isEnable ? 1 : 0);                 // if (PED::IS_PED_IN_ANY_VEHICLE(PLAYER::PLAYER_PED_ID(), true) || PED::IS_PED_GETTING_INTO_A_VEHICLE(PLAYER::PLAYER_PED_ID()))
     }
 
     /// <summary>
@@ -485,7 +485,7 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void TriggerMiniTank(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.oVMYCar + 6919, isEnable ? 1 : 0);
+        Globals.Set_Global_Value(Base.oVMYCar + 6957, isEnable ? 1 : 0);
     }
 
     /// <summary>
@@ -496,7 +496,7 @@ public static class Online
     {
         Globals.Set_Global_Value(Base.oNETTimeHelp + 63 + 10, 17);
         await Task.Delay(100);
-        Globals.Set_Global_Value(Base.oVMYCar + 960, 1);
+        Globals.Set_Global_Value(Base.oVMYCar + 975, 1);
     }
 
     /// <summary>
@@ -505,6 +505,6 @@ public static class Online
     /// <param name="isEnable"></param>
     public static void KosatkaMissleCooldown(bool isEnable)
     {
-        Globals.Set_Global_Value(Base.Default + 30464, isEnable ? 0 : 60000);           // joaat("IH_SUBMARINE_MISSILES_COOLDOWN")
+        Globals.Set_Global_Value(Base.Default + 29635, isEnable ? 0 : 60000);           // joaat("IH_SUBMARINE_MISSILES_COOLDOWN")
     }
 }

--- a/GTA5Core/Features/STATS.cs
+++ b/GTA5Core/Features/STATS.cs
@@ -20,23 +20,23 @@ public enum MPStatTypes
 
 public static class STATS
 {
-    private const int character = 1574925;
+    private const int character = 1574926;
 
     private const int stat_data_type = 0x026b66d8;
 
-    private const int stat_structure = 2749147 + 305;
+    private const int stat_structure = 2749550 + 305;
 
-    private const int stat_get_int_outvalue = 2750546 + 267;
+    private const int stat_get_int_outvalue = 2750949 + 269;
 
-    private const int stat_get_int_switch = 1668317;
-    private const int stat_get_int_case = stat_get_int_switch + 1136;   // https://pastebin.com/VbfAmLYB 
-    private const int stat_set_int_case = stat_get_int_switch + 1139;
+    private const int stat_get_int_switch = 1668667;
+    private const int stat_get_int_case = stat_get_int_switch + 1135;   // https://pastebin.com/VbfAmLYB 
+    private const int stat_set_int_case = stat_get_int_switch + 1138;
 
-    private const int stat_set_int_hash = 1679796 + 1 + 3;
+    private const int stat_set_int_hash = 1680145 + 1 + 3;
     private const int stat_set_int_value = 982384 + 5587;
 
-    private const int stat_bool_hash = 1679804 + 1 + 17;
-    private const int stat_bool_value = 2695956;
+    private const int stat_bool_hash = 1680153 + 1 + 17;
+    private const int stat_bool_value = 2696177;
 
     private static long StatGetIntHash()
     {

--- a/GTA5Core/Features/Teleport.cs
+++ b/GTA5Core/Features/Teleport.cs
@@ -121,17 +121,17 @@ public static class Teleport
             var pCPed = Game.GetCPed();
             if (!Vehicle.IsInVehicle(pCPed))
             {
-                Globals.Set_Global_Value(4521801 + 946 + 0, vector3.X);
-                Globals.Set_Global_Value(4521801 + 946 + 1, vector3.Y);
-                Globals.Set_Global_Value(4521801 + 946 + 2, vector3.Z);
-                Globals.Set_Global_Value(2672741 + 63 + 22, 0);
-                Globals.Set_Global_Value(4521801 + 943, 20);
+                Globals.Set_Global_Value(4521801 + 948 + 0, vector3.X);
+                Globals.Set_Global_Value(4521801 + 948 + 1, vector3.Y);
+                Globals.Set_Global_Value(4521801 + 948 + 2, vector3.Z);
+                Globals.Set_Global_Value(2672855 + 63 + 22, 0);
+                Globals.Set_Global_Value(4521801 + 945, 20);
 
-                while (Globals.Get_Global_Value<int>(4521801 + 943) == 20)
+                while (Globals.Get_Global_Value<int>(4521801 + 945) == 20)
                 {
                 }
 
-                Globals.Set_Global_Value(4521801 + 943, -1);
+                Globals.Set_Global_Value(4521801 + 945, -1);
             }
         }
     }
@@ -144,7 +144,7 @@ public static class Teleport
             return;
 
         // 禁用越界死亡
-        Globals.Set_Global_Value(2738587 + 6920, 1);     // freemode - joaat("TRI_WARP")
+        Globals.Set_Global_Value(2738934 + 6958, 1);     // freemode - "TRI_WARP"
 
         var pCPed = Game.GetCPed();
 

--- a/GTA5Core/Features/Vehicle.cs
+++ b/GTA5Core/Features/Vehicle.cs
@@ -173,8 +173,8 @@ public static class Vehicle
     /// <param name="index"></param>
     public static void RequestPersonalVehicle(int index)
     {
-        Globals.Set_Global_Value(Base.oVMYCar + 992, index);
-        Globals.Set_Global_Value(Base.oVMYCar + 989, 1);
+        Globals.Set_Global_Value(Base.oVMYCar + 1007, index);
+        Globals.Set_Global_Value(Base.oVMYCar + 1004, 1);
     }
 
     /// <summary>

--- a/GTA5Core/Offsets/Base.cs
+++ b/GTA5Core/Offsets/Base.cs
@@ -13,13 +13,13 @@ public struct Base
 
     public const int SessionSwitchState = 1574589;          // if (AUDIO::IS_AUDIO_SCENE_ACTIVE("MP_POST_MATCH_TRANSITION_SCENE"))
     public const int SessionSwitchCache = 1574589 + 2;
-    public const int SessionTransitionState = 1575008;
-    public const int SessionSwitchType = 1575032;           // NETWORK::NETWORK_SESSION_SET_UNIQUE_CREW_LIMIT(1);
+    public const int SessionTransitionState = 1575011;
+    public const int SessionSwitchType = 1575035;           // NETWORK::NETWORK_SESSION_SET_UNIQUE_CREW_LIMIT(1);
 
     // Vehicle Menus Globals
-    public const int oVMCreate = 2695991;                   // Create any vehicle. STREAMING::REQUEST_MODEL(Global_2694562.f_27.f_66);
-    public const int oVMYCar = 2738587;                     // Get my car. HUD::HIDE_HUD_AND_RADAR_THIS_FRAME();
-    public const int oVGETIn = 2640095;                     // Spawn into vehicle. if (SCRIPT::IS_THREAD_ACTIVE(Global_
+    public const int oVMCreate = 2696212;                   // Create any vehicle. STREAMING::REQUEST_MODEL(Global_2694562.f_27.f_66);
+    public const int oVMYCar = 2738934;                     // Get my car. HUD::HIDE_HUD_AND_RADAR_THIS_FRAME();
+    public const int oVGETIn = 2640096;                     // Spawn into vehicle. if (SCRIPT::IS_THREAD_ACTIVE(Global_
     public const int oVMSlots = 1586504;                    // Get vehicle slots. if (!NETWORK::NETWORK_DOES_NETWORK_ID_EXIST
 
     // Some Player / Network times associated Globals

--- a/GTA5Core/Offsets/Base.cs
+++ b/GTA5Core/Offsets/Base.cs
@@ -23,7 +23,7 @@ public struct Base
     public const int oVMSlots = 1586504;                    // Get vehicle slots. if (!NETWORK::NETWORK_DOES_NETWORK_ID_EXIST
 
     // Some Player / Network times associated Globals
-    public const int oNETTimeHelp = 2672741;                // if (ENTITY::IS_ENTITY_DEAD(vehiclePedIsIn, false) || !VEHICLE::IS_VEHICLE_DRIVEABLE(vehiclePedIsIn, false)
-    public const int oPlayerIDHelp = 2657921;               // NETWORK::NETWORK_SET_CURRENT_SPAWN_LOCATION_OPTION(MISC::GET_HASH_KEY(   // Global_2657704[PLAYER::PLAYER_ID() /*463*/].f_321.f_11 = _INVALID_PLAYER_INDEX_0();
-    public const int oPlayerGA = 2672741;
+    public const int oNETTimeHelp = 2672855;                // if (ENTITY::IS_ENTITY_DEAD(vehiclePedIsIn, false) || !VEHICLE::IS_VEHICLE_DRIVEABLE(vehiclePedIsIn, false)
+    public const int oPlayerIDHelp = 2657971;               // NETWORK::NETWORK_SET_CURRENT_SPAWN_LOCATION_OPTION(MISC::GET_HASH_KEY(   // Global_2657704[PLAYER::PLAYER_ID() /*463*/].f_321.f_11 = _INVALID_PLAYER_INDEX_0();
+    public const int oPlayerGA = 2672855;
 }

--- a/GTA5Core/Offsets/Base.cs
+++ b/GTA5Core/Offsets/Base.cs
@@ -20,7 +20,7 @@ public struct Base
     public const int oVMCreate = 2696212;                   // Create any vehicle. STREAMING::REQUEST_MODEL(Global_2694562.f_27.f_66);
     public const int oVMYCar = 2738934;                     // Get my car. HUD::HIDE_HUD_AND_RADAR_THIS_FRAME();
     public const int oVGETIn = 2640096;                     // Spawn into vehicle. if (SCRIPT::IS_THREAD_ACTIVE(Global_
-    public const int oVMSlots = 1586504;                    // Get vehicle slots. if (!NETWORK::NETWORK_DOES_NETWORK_ID_EXIST
+    public const int oVMSlots = 1586521;                    // Get vehicle slots. if (!NETWORK::NETWORK_DOES_NETWORK_ID_EXIST
 
     // Some Player / Network times associated Globals
     public const int oNETTimeHelp = 2672855;                // if (ENTITY::IS_ENTITY_DEAD(vehiclePedIsIn, false) || !VEHICLE::IS_VEHICLE_DRIVEABLE(vehiclePedIsIn, false)

--- a/GTA5Core/Offsets/CPedFactory.cs
+++ b/GTA5Core/Offsets/CPedFactory.cs
@@ -92,9 +92,9 @@ public struct CPlayerInfo                               // 0x10A8
     public const int CrossHairZ = 0x358;
     public const int WantedCanChange = 0x78C;           // float
     public const int NPCIgnore = 0x8C0;                 // int32
-    public const int WantedLevel = 0x8D8;               // int32
+    public const int WantedLevel = 0x8E8;               // int32
     public const int WantedLevelDisplay = 0x8DC;        // int32
-    public const int RunSpeed = 0xD40;                  // float
+    public const int RunSpeed = 0xD50;                  // float
     public const int Stamina = 0xD44;                   // float
     public const int StaminaRegen = 0xD48;              // float
     public const int WeaponDamageMult = 0xD5C;          // float

--- a/GTA5Menu/Views/ExternalMenu/PlayerListView.xaml.cs
+++ b/GTA5Menu/Views/ExternalMenu/PlayerListView.xaml.cs
@@ -85,7 +85,7 @@ public partial class PlayerListView : UserControl
             var isHost = hostToken1 == hostToken2;
 
             // 是否为脚本主机
-            var scriptHost = Globals.Get_Global_Value<int>(2650208 + 1);
+            var scriptHost = Globals.Get_Global_Value<int>(2650208 + 1); // TODO: outdated
 
             ////////////////////////////////////////////
 
@@ -121,9 +121,9 @@ public partial class PlayerListView : UserControl
             var armor = Memory.Read<float>(pCPed + CPed.Armor);
             var noRagdoll = Memory.Read<byte>(pCPed + CPed.Ragdoll);
 
-            var rank = Globals.Get_Global_Value<int>(1845263 + 1 + i * 877 + 205 + 6);
-            var money = Globals.Get_Global_Value<long>(1845263 + 1 + i * 877 + 205 + 56);     // _MPPLY_STAT_SET_INT(joaat("MPPLY_GLOBALXP"), iParam0);
-            var cash = Globals.Get_Global_Value<long>(1845263 + 1 + i * 877 + 205 + 3);
+            var rank = Globals.Get_Global_Value<int>(1845281 + 1 + i * 883 + 206 + 6);
+            var money = Globals.Get_Global_Value<long>(1845281 + 1 + i * 883 + 206 + 56);     // STATS::PLAYSTATS_AWARD_XP(amount, -1158693853, -1175948474);
+            var cash = Globals.Get_Global_Value<long>(1845281 + 1 + i * 883 + 206 + 3);
 
             var rid = Memory.Read<long>(pCPlayerInfo + CPlayerInfo.RockstarID);
             var name = Memory.ReadString(pCPlayerInfo + CPlayerInfo.Name, 20);

--- a/GTA5MenuExtra/Views/HeistsEditor/Apartment/MoneyView.xaml.cs
+++ b/GTA5MenuExtra/Views/HeistsEditor/Apartment/MoneyView.xaml.cs
@@ -8,8 +8,8 @@ namespace GTA5MenuExtra.Views.HeistsEditor.Apartment;
 /// </summary>
 public partial class MoneyView : UserControl
 {
-    private const int apart_ratio = 1930201 + 3008;     // +1 +2 +3 +4
-    private const int apart_money = 262145 + 9314; //HEIST_FLEECA_JOB_CASH_REWARD
+    private const int apart_ratio = 1930926 + 3008;     // +1 +2 +3 +4
+    private const int apart_money = 262145 + 9171; //HEIST_FLEECA_JOB_CASH_REWARD
 
     public MoneyView()
     {

--- a/GTA5MenuExtra/Views/HeistsEditor/Casino/MoneyView.xaml.cs
+++ b/GTA5MenuExtra/Views/HeistsEditor/Casino/MoneyView.xaml.cs
@@ -8,11 +8,11 @@ namespace GTA5MenuExtra.Views.HeistsEditor.Casino;
 /// </summary>
 public partial class MoneyView : UserControl
 {
-    private const int player_ratio = 1963945 + 1497 + 736 + 92;
-    private const int player_money = 262145 + 29082;     // -1638885821
+    private const int player_ratio = 1964849 + 1497 + 736 + 92;
+    private const int player_money = 262145 + 28327;     // -1638885821
 
-    private const int ai_ratio = 262145 + 29093;
-    private const int lester_ratio = 262145 + 29068;     // joaat("CH_LESTER_CUT")
+    private const int ai_ratio = 262145 + 28338;
+    private const int lester_ratio = 262145 + 28313;     // joaat("CH_LESTER_CUT")
 
     public MoneyView()
     {

--- a/GTA5MenuExtra/Views/HeistsEditor/Contract/MoneyView.xaml.cs
+++ b/GTA5MenuExtra/Views/HeistsEditor/Contract/MoneyView.xaml.cs
@@ -8,8 +8,8 @@ namespace GTA5MenuExtra.Views.HeistsEditor.Contract;
 /// </summary>
 public partial class MoneyView : UserControl
 {
-    private const int fixer_ratio = 262145 + 32071;     // -2108119120  joaat("FIXER_FINALE_LEADER_CASH_REWARD")     Global_262145.f_31955
-    private const int tuner_ratio = 262145 + 31323;     // -920277662   joaat("TUNER_ROBBERY_LEADER_CASH_REWARD0")   Global_262145.f_31249[0]
+    private const int fixer_ratio = 262145 + 31084;     // -2108119120  joaat("FIXER_FINALE_LEADER_CASH_REWARD")     Global_262145.f_31955
+    private const int tuner_ratio = 262145 + 30338;     // -920277662   joaat("TUNER_ROBBERY_LEADER_CASH_REWARD0")   Global_262145.f_31249[0]
 
     public MoneyView()
     {

--- a/GTA5MenuExtra/Views/HeistsEditor/Doomsday/MoneyView.xaml.cs
+++ b/GTA5MenuExtra/Views/HeistsEditor/Doomsday/MoneyView.xaml.cs
@@ -8,8 +8,8 @@ namespace GTA5MenuExtra.Views.HeistsEditor.Doomsday;
 /// </summary>
 public partial class MoneyView : UserControl
 {
-    private const int player_ratio = 1959865 + 812 + 50;    
-    private const int player_money = 262145 + 9319;         // joaat("GANGOPS_THE_IAA_JOB_CASH_REWARD")
+    private const int player_ratio = 1960755 + 812 + 50;    
+    private const int player_money = 262145 + 9176;         // joaat("GANGOPS_THE_IAA_JOB_CASH_REWARD")
 
     public MoneyView()
     {

--- a/GTA5MenuExtra/Views/HeistsEditor/Perico/MoneyView.xaml.cs
+++ b/GTA5MenuExtra/Views/HeistsEditor/Perico/MoneyView.xaml.cs
@@ -11,15 +11,15 @@ public partial class MoneyView : UserControl
     /// <summary>
     /// 玩家分红
     /// </summary>
-    private const int player_ratio = 1970744 + 831 + 56;
+    private const int player_ratio = 1971648 + 831 + 56;
     /// <summary>
     /// 主要目标价值
     /// </summary>
-    private const int target_money = 262145 + 30259;    // 132820683    joaat("IH_PRIMARY_TARGET_VALUE_TEQUILA")     Global_262145.f_30259
+    private const int target_money = 262145 + 29458;    // 132820683    joaat("IH_PRIMARY_TARGET_VALUE_TEQUILA")     Global_262145.f_30259
     /// <summary>
     /// 背包容量
     /// </summary>
-    private const int bag_size = 262145 + 30009;        // 1859395035   Global_262145.f_30009
+    private const int bag_size = 262145 + 29211;        // 1859395035   Global_262145.f_30009
 
     public MoneyView()
     {


### PR DESCRIPTION
[offsets]
通缉等级
奔跑速度

[globals]
stats读写
载具生成
战局切换
抢劫任务、合约 分红和杂项
在线模式杂项功能(移除轨道炮CD,战局雪天,人间蒸发,幽灵组织,警察无视犯罪,贿赂当局,显示玩家,牛鲨睾酮,请求虎鲸,虎鲸导弹冷却,进入RC匪徒,进入迷你坦克,移除公共电话任务合约冷却,移除事务所安保合约冷却,移除恐霸客户差事冷却,移除CEO工作冷却,移除夜总会出货CD,移除机库进货CD,结束过场动画,断开战局连接,移除进出口大亨出货CD,移除摩托帮进货延迟,移除地堡进货延迟,移除出售CEO板条箱冷却,移除购买CEO板条箱冷却,设置CEO特殊货物类型,启用CEO特殊货物,设置角色AP经验倍数,设置车友会等级经验倍数,呼叫支援直升机,呼叫空袭、挂机防踢，免费更改角色外观，移除更改角色外观冷却，允许非公共战局运货,移除被动模式CD,移除自杀CD)
传送(内置方法)
随身技工
掉落物/刷武器
角色索引
获取网络时间
判断是否在线上模式