### PR TITLE
常规修复/优化

### DIFF
--- a/GTA5Core/GTA/Objects/CCTV.cs
+++ b/GTA5Core/GTA/Objects/CCTV.cs
@@ -60,5 +60,8 @@ public static class CCTV
         
         2452560208,     // hei_prop_bank_cctv_02
         289451089,      // p_cctv_s
+
+        3061645218,     // ch_prop_ch_cctv_cam_02a
+        1306601124,     // ch_prop_ch_cctv_cam_01a
     };
 }

--- a/GTA5Core/GTA/Objects/CCTV.cs
+++ b/GTA5Core/GTA/Objects/CCTV.cs
@@ -63,5 +63,7 @@ public static class CCTV
 
         3061645218,     // ch_prop_ch_cctv_cam_02a
         1306601124,     // ch_prop_ch_cctv_cam_01a
+
+        4047557484,     // xm_prop_x17_server_farm_cctv_01
     };
 }

--- a/GTA5Menu/GTA5MenuWindow.xaml
+++ b/GTA5Menu/GTA5MenuWindow.xaml
@@ -74,8 +74,8 @@
                     Content="窗口置顶"
                     WindowChrome.IsHitTestVisibleInChrome="True" />
                 <CheckBox
-                    x:Name="CheckBox_IsShowInTaskbar"
-                    Click="CheckBox_IsShowInTaskbar_Click"
+                    x:Name="CheckBox_IsHideInTaskbar"
+                    Click="CheckBox_IsHideInTaskbar_Click"
                     Content="隐藏任务栏图标"
                     WindowChrome.IsHitTestVisibleInChrome="True" />
             </StackPanel>

--- a/GTA5Menu/GTA5MenuWindow.xaml.cs
+++ b/GTA5Menu/GTA5MenuWindow.xaml.cs
@@ -122,16 +122,16 @@ public partial class GTA5MenuWindow
     {
         var isUseDelKey = IniHelper.ReadValue("GTA5Menu", "IsUseDelKeyShowMenu").Equals("True", StringComparison.OrdinalIgnoreCase);
         var isTopMost = IniHelper.ReadValue("GTA5Menu", "IsTopMostMenu").Equals("True", StringComparison.OrdinalIgnoreCase);
-        var isShowInTaskbar = IniHelper.ReadValue("GTA5Menu", "IsShowInTaskbarMenu").Equals("True", StringComparison.OrdinalIgnoreCase);
+        var isHideInTaskbar = IniHelper.ReadValue("GTA5Menu", "IsHideInTaskbarMenu").Equals("True", StringComparison.OrdinalIgnoreCase);
 
         RadioButton_ShowMenuKey_Oem3.IsChecked = !isUseDelKey;
         RadioButton_ShowMenuKey_Del.IsChecked = isUseDelKey;
 
         CheckBox_IsTopMost.IsChecked = isTopMost;
-        CheckBox_IsShowInTaskbar.IsChecked = isShowInTaskbar;
+        CheckBox_IsHideInTaskbar.IsChecked = isHideInTaskbar;
 
         this.Topmost = isTopMost;
-        this.ShowInTaskbar = isShowInTaskbar;
+        this.ShowInTaskbar = !isHideInTaskbar;
 
         this.IsUseDelKeyShowMenu = RadioButton_ShowMenuKey_Del.IsChecked == true;
     }
@@ -144,7 +144,7 @@ public partial class GTA5MenuWindow
         IniHelper.WriteValue("GTA5Menu", "IsUseDelKeyShowMenu", $"{RadioButton_ShowMenuKey_Del.IsChecked == true}");
 
         IniHelper.WriteValue("GTA5Menu", "IsTopMostMenu", $"{CheckBox_IsTopMost.IsChecked == true}");
-        IniHelper.WriteValue("GTA5Menu", "IsShowInTaskbarMenu", $"{CheckBox_IsShowInTaskbar.IsChecked == true}");
+        IniHelper.WriteValue("GTA5Menu", "IsHideInTaskbarMenu", $"{CheckBox_IsHideInTaskbar.IsChecked == true}");
     }
 
     /// <summary>
@@ -201,9 +201,9 @@ public partial class GTA5MenuWindow
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    private void CheckBox_IsShowInTaskbar_Click(object sender, RoutedEventArgs e)
+    private void CheckBox_IsHideInTaskbar_Click(object sender, RoutedEventArgs e)
     {
-        if (CheckBox_IsShowInTaskbar.IsChecked == true)
+        if (CheckBox_IsHideInTaskbar.IsChecked == true)
             this.ShowInTaskbar = false;
         else
             this.ShowInTaskbar = true;

--- a/GTA5Menu/Views/ExternalMenu/OnlineOptionView.xaml
+++ b/GTA5Menu/Views/ExternalMenu/OnlineOptionView.xaml
@@ -128,7 +128,10 @@
                 <Button Click="Button_Blips_Click" Content="改装铺" />
                 <Button Click="Button_Blips_Click" Content="事务所" />
                 <Button Click="Button_Blips_Click" Content="竞技场工作室" />
-                <Button Click="Button_Blips_Click" Content="怪胎店" />
+                <Button
+                    x:Name="Button_Teleport_Freak_Shop"
+                    Click="Button_Teleport_Freak_Shop_Click"
+                    Content="怪胎店" />
                 <Button Click="Button_Blips_Click" Content="回收站" />
                 <Button Click="Button_Blips_Click" Content="保金办公室" />
             </WrapPanel>
@@ -140,7 +143,10 @@
                 <Button Click="Button_Blips_Click" Content="顶级豪华车业" />
                 <Button Click="Button_Blips_Click" Content="好麦坞车友俱乐部" />
                 <Button Click="Button_Blips_Click" Content="录音A工作室" />
-                <Button Click="Button_Blips_Click" Content="枪支厢型车" />
+                <Button
+                    x:Name="Button_Teleport_Gun_Van"
+                    Click="Button_Teleport_Gun_Van_Click"
+                    Content="枪支厢型车" />
                 <Button Click="Button_Blips_Click" Content="街头毒贩" />
             </WrapPanel>
             <Separator Margin="8,5,8,5" />

--- a/GTA5Menu/Views/ExternalMenu/OnlineOptionView.xaml
+++ b/GTA5Menu/Views/ExternalMenu/OnlineOptionView.xaml
@@ -128,10 +128,7 @@
                 <Button Click="Button_Blips_Click" Content="改装铺" />
                 <Button Click="Button_Blips_Click" Content="事务所" />
                 <Button Click="Button_Blips_Click" Content="竞技场工作室" />
-                <Button
-                    x:Name="Button_Teleport_Freak_Shop"
-                    Click="Button_Teleport_Freak_Shop_Click"
-                    Content="怪胎店" />
+                <Button Click="Button_Teleport_Freak_Shop_Click" Content="怪胎店" />
                 <Button Click="Button_Blips_Click" Content="回收站" />
                 <Button Click="Button_Blips_Click" Content="保金办公室" />
             </WrapPanel>
@@ -143,10 +140,7 @@
                 <Button Click="Button_Blips_Click" Content="顶级豪华车业" />
                 <Button Click="Button_Blips_Click" Content="好麦坞车友俱乐部" />
                 <Button Click="Button_Blips_Click" Content="录音A工作室" />
-                <Button
-                    x:Name="Button_Teleport_Gun_Van"
-                    Click="Button_Teleport_Gun_Van_Click"
-                    Content="枪支厢型车" />
+                <Button Click="Button_Teleport_Gun_Van_Click" Content="枪支厢型车" />
                 <Button Click="Button_Blips_Click" Content="街头毒贩" />
             </WrapPanel>
             <Separator Margin="8,5,8,5" />

--- a/GTA5Menu/Views/ExternalMenu/OnlineOptionView.xaml.cs
+++ b/GTA5Menu/Views/ExternalMenu/OnlineOptionView.xaml.cs
@@ -188,15 +188,15 @@ public partial class OnlineOptionView : UserControl
         Teleport.SetTeleportPosition(new Vector3(605.638f, -409.474f, 24.748f));
     }
 
-    private void Button_Teleport_Gun_Van_Click(object sender, RoutedEventArgs e)
+    private async void Button_Teleport_Gun_Van_Click(object sender, RoutedEventArgs e)
     {
         AudioHelper.PlayClickSound();
 
-        Vector3 GanvanPos;
-        GanvanPos.X = Globals.Get_Global_Value<float>(1949748); // freemode.ysc return -29.532f, 6435.136f, 31.162f;
-        GanvanPos.Y = Globals.Get_Global_Value<float>(1949748 + 1);
-        GanvanPos.Z = Globals.Get_Global_Value<float>(1949748 + 2) + 2;
-        Teleport.SetTeleportPosition(GanvanPos);
+        Globals.Set_Global_Value<float>(1949748, -1005.75f); // freemode.ysc return -29.532f, 6435.136f, 31.162f;
+        Globals.Set_Global_Value<float>(1949748 + 1, 25.2f);
+        Globals.Set_Global_Value<float>(1949748 + 2, 49.25f);
+        await Task.Delay(2000);
+        Teleport.SetTeleportPosition(new Vector3(-1001.53f, 25.01f, 52.01f));
     }
 
     private void Button_MerryweatherServices_Click(object sender, RoutedEventArgs e)

--- a/GTA5Menu/Views/ExternalMenu/OnlineOptionView.xaml.cs
+++ b/GTA5Menu/Views/ExternalMenu/OnlineOptionView.xaml.cs
@@ -187,12 +187,13 @@ public partial class OnlineOptionView : UserControl
 
         Teleport.SetTeleportPosition(new Vector3(605.638f, -409.474f, 24.748f));
     }
+
     private void Button_Teleport_Gun_Van_Click(object sender, RoutedEventArgs e)
     {
         AudioHelper.PlayClickSound();
 
         Vector3 GanvanPos;
-        GanvanPos.X = Globals.Get_Global_Value<float>(1949748);
+        GanvanPos.X = Globals.Get_Global_Value<float>(1949748); // freemode.ysc return -29.532f, 6435.136f, 31.162f;
         GanvanPos.Y = Globals.Get_Global_Value<float>(1949748 + 1);
         GanvanPos.Z = Globals.Get_Global_Value<float>(1949748 + 2) + 2;
         Teleport.SetTeleportPosition(GanvanPos);

--- a/GTA5Menu/Views/ExternalMenu/OnlineOptionView.xaml.cs
+++ b/GTA5Menu/Views/ExternalMenu/OnlineOptionView.xaml.cs
@@ -181,6 +181,23 @@ public partial class OnlineOptionView : UserControl
         }
     }
 
+    private void Button_Teleport_Freak_Shop_Click (object sender, RoutedEventArgs e)
+    {
+        AudioHelper.PlayClickSound();
+
+        Teleport.SetTeleportPosition(new Vector3(605.638f, -409.474f, 24.748f));
+    }
+    private void Button_Teleport_Gun_Van_Click(object sender, RoutedEventArgs e)
+    {
+        AudioHelper.PlayClickSound();
+
+        Vector3 GanvanPos;
+        GanvanPos.X = Globals.Get_Global_Value<float>(1949748);
+        GanvanPos.Y = Globals.Get_Global_Value<float>(1949748 + 1);
+        GanvanPos.Z = Globals.Get_Global_Value<float>(1949748 + 2) + 2;
+        Teleport.SetTeleportPosition(GanvanPos);
+    }
+
     private void Button_MerryweatherServices_Click(object sender, RoutedEventArgs e)
     {
         AudioHelper.PlayClickSound();

--- a/GTA5MenuExtra/Views/HeistsEditor/Apartment/MoneyView.xaml
+++ b/GTA5MenuExtra/Views/HeistsEditor/Apartment/MoneyView.xaml
@@ -35,22 +35,14 @@
             <StackPanel Margin="5">
                 <TextBlock Style="{StaticResource TextBlockStyle_Title}" Text="分红比例" />
                 <UniformGrid Columns="2">
-                    <TextBlock Text="（房主）玩家1" />
+                    <TextBlock Text="本地分红" />
                     <TextBox x:Name="TextBox_Apart_Player1" />
-                    <TextBlock Text="玩家2" />
-                    <TextBox x:Name="TextBox_Apart_Player2" />
-                    <TextBlock Text="玩家3" />
-                    <TextBox x:Name="TextBox_Apart_Player3" />
-                    <TextBlock Text="玩家4" />
-                    <TextBox x:Name="TextBox_Apart_Player4" />
                 </UniformGrid>
 
                 <TextBlock Style="{StaticResource TextBlockStyle_Hint}">
                     类型：整数型INT，范围大于等于0
                 </TextBlock>
-                <TextBlock Style="{StaticResource TextBlockStyle_Hint}">
-                    提示：需要是房主修改才有效
-                </TextBlock>
+                <TextBlock Style="{StaticResource TextBlockStyle_Hint}"><Run Text="提示："/><Run Text="只能修改自己的本地分红，请在任务启动后修改"/><Run Language="zh-cn" Text="。本地分红不会呈现在计划面板上。"/></TextBlock>
             </StackPanel>
 
             <StackPanel Margin="5">

--- a/GTA5MenuExtra/Views/HeistsEditor/Apartment/MoneyView.xaml
+++ b/GTA5MenuExtra/Views/HeistsEditor/Apartment/MoneyView.xaml
@@ -42,7 +42,7 @@
                 <TextBlock Style="{StaticResource TextBlockStyle_Hint}">
                     类型：整数型INT，范围大于等于0
                 </TextBlock>
-                <TextBlock Style="{StaticResource TextBlockStyle_Hint}"><Run Text="提示："/><Run Text="只能修改自己的本地分红，请在任务启动后修改"/><Run Language="zh-cn" Text="。本地分红不会呈现在计划面板上。"/></TextBlock>
+                <TextBlock Style="{StaticResource TextBlockStyle_Hint}"><Run Text="提示："/><Run Text="公寓抢劫只能修改自己的本地分红，请在完全进入任务地图后至任务完成动画出现前的任意时间修改。本地分红不会体现在计划面板上。"/></TextBlock>
             </StackPanel>
 
             <StackPanel Margin="5">

--- a/GTA5MenuExtra/Views/HeistsEditor/Apartment/MoneyView.xaml.cs
+++ b/GTA5MenuExtra/Views/HeistsEditor/Apartment/MoneyView.xaml.cs
@@ -8,7 +8,7 @@ namespace GTA5MenuExtra.Views.HeistsEditor.Apartment;
 /// </summary>
 public partial class MoneyView : UserControl
 {
-    private const int apart_ratio = 1930926 + 3008;     // +1 +2 +3 +4
+    private const int apart_ratio = 2685444 + 6403;     // +1 +2 +3 +4
    /* private const int apart_money = 262145 + 9171; //HEIST_FLEECA_JOB_CASH_REWARD*/
 
     public MoneyView()
@@ -21,9 +21,6 @@ public partial class MoneyView : UserControl
         AudioHelper.PlayClickSound();
 
         TextBox_Apart_Player1.Text = Globals.Get_Global_Value<int>(apart_ratio + 1).ToString();
-        TextBox_Apart_Player2.Text = Globals.Get_Global_Value<int>(apart_ratio + 2).ToString();
-        TextBox_Apart_Player3.Text = Globals.Get_Global_Value<int>(apart_ratio + 3).ToString();
-        TextBox_Apart_Player4.Text = Globals.Get_Global_Value<int>(apart_ratio + 4).ToString();
 
         TextBox_Apart_Fleeca.Text = Globals.Get_Global_Value<int>(Tunables.Index(RAGE.JOAAT("HEIST_FLEECA_JOB_CASH_REWARD"))).ToString();
         TextBox_Apart_PrisonBreak.Text = Globals.Get_Global_Value<int>(Tunables.Index(RAGE.JOAAT("HEIST_PRISON_BREAK_CASH_REWARD"))).ToString();
@@ -39,9 +36,6 @@ public partial class MoneyView : UserControl
         AudioHelper.PlayClickSound();
 
         if (!int.TryParse(TextBox_Apart_Player1.Text, out int player1) ||
-            !int.TryParse(TextBox_Apart_Player2.Text, out int player2) ||
-            !int.TryParse(TextBox_Apart_Player3.Text, out int player3) ||
-            !int.TryParse(TextBox_Apart_Player4.Text, out int player4) ||
 
             !int.TryParse(TextBox_Apart_Fleeca.Text, out int apart1) ||
             !int.TryParse(TextBox_Apart_PrisonBreak.Text, out int apart2) ||
@@ -53,10 +47,7 @@ public partial class MoneyView : UserControl
             return;
         }
 
-        Globals.Set_Global_Value(apart_ratio + 1, player1);
-        Globals.Set_Global_Value(apart_ratio + 2, player2);
-        Globals.Set_Global_Value(apart_ratio + 3, player3);
-        Globals.Set_Global_Value(apart_ratio + 4, player4);
+        Globals.Set_Global_Value(apart_ratio, player1);
 
         Globals.Set_Global_Value(Tunables.Index(RAGE.JOAAT("HEIST_FLEECA_JOB_CASH_REWARD")), apart1);
         Globals.Set_Global_Value(Tunables.Index(RAGE.JOAAT("HEIST_PRISON_BREAK_CASH_REWARD")), apart2);

--- a/GTA5MenuExtra/Views/HeistsEditor/Apartment/MoneyView.xaml.cs
+++ b/GTA5MenuExtra/Views/HeistsEditor/Apartment/MoneyView.xaml.cs
@@ -20,7 +20,7 @@ public partial class MoneyView : UserControl
     {
         AudioHelper.PlayClickSound();
 
-        TextBox_Apart_Player1.Text = Globals.Get_Global_Value<int>(apart_ratio + 1).ToString();
+        TextBox_Apart_Player1.Text = Globals.Get_Global_Value<int>(apart_ratio).ToString();
 
         TextBox_Apart_Fleeca.Text = Globals.Get_Global_Value<int>(Tunables.Index(RAGE.JOAAT("HEIST_FLEECA_JOB_CASH_REWARD"))).ToString();
         TextBox_Apart_PrisonBreak.Text = Globals.Get_Global_Value<int>(Tunables.Index(RAGE.JOAAT("HEIST_PRISON_BREAK_CASH_REWARD"))).ToString();


### PR DESCRIPTION
Closes #919
使变量名与显示文本意义相符，避免后续维护时混淆。

怪胎店 Blip 不唯一，不完全适合Blip传送。但位置坐标固定，可直接使用坐标传送
枪支厢型车只有接近时才添加Blip，无法使用Blip传送。位置不固定， 修改Globals使厢型车生成在某位置然后传送

完善cctv列表(补充H3\H4的cam)

移除老抢劫分红修改，因为这种方法早就失效了，即使是房主也不能修改他人分红。用本地分红替代此功能，本地分红可以在结算前任意时间修改且不会被其他玩家发现